### PR TITLE
Add network.outbound and network.listen capabilities

### DIFF
--- a/DEVELOPMENT_PLAN.md
+++ b/DEVELOPMENT_PLAN.md
@@ -193,15 +193,43 @@ Exit criteria:
 
 ---
 
-### M4 — Enforcement v1 (network)
+### M4 — Enforcement v1 (network) ✓
 
-* Outbound network blocking
-* Minimal hook set
-* Clear failure messages
+* Outbound network blocking ✓
+* Minimal hook set ✓
+* Clear failure messages ✓
+
+Implementation:
+
+* `network.outbound` capability (0 arguments) grants outbound TCP connection rights
+* Instrumented classes:
+  * `java.net.Socket` - constructors and connect() method
+  * `java.nio.channels.SocketChannel` - connect() method
+* BootstrapEnforcer.onNetworkConnect() callbacks for enforcement
+* PolicyEnforcer.checkNetworkOutbound() for policy evaluation
+* Retransformation support for bootstrap-loaded classes via DiscoveryStrategy.Reiterating
 
 Exit criteria:
 
-* demonstrable prevention of outbound socket creation
+* demonstrable prevention of outbound socket creation ✓
+
+---
+
+### M4.1 — Network Listen Enforcement ✓
+
+* `network.listen` capability grants server socket binding rights
+  * `network.listen` (no arguments) - allows binding to any port
+  * `network.listen(port)` (1 integer argument) - allows binding to specific port only
+* Instrumented classes:
+  * `java.net.ServerSocket` - constructors and bind() method
+  * `java.nio.channels.ServerSocketChannel` - bind() method
+* BootstrapEnforcer.onNetworkListen(port) callbacks for enforcement
+* PolicyEnforcer.checkNetworkListen(context, port) for policy evaluation
+* Separate from network.outbound for fine-grained control
+
+Exit criteria:
+
+* demonstrable prevention of unauthorized server socket creation ✓
 
 ---
 
@@ -229,7 +257,9 @@ Exit criteria:
 ## Initial capability set (v0.1.0)
 
 * `fs.read(root, glob)`
+* `fs.write(root, glob)`
 * `network.outbound`
+* `network.listen`
 
 Everything else deferred.
 

--- a/agent-bootstrap/src/main/java/org/jguard/bootstrap/BootstrapEnforcer.java
+++ b/agent-bootstrap/src/main/java/org/jguard/bootstrap/BootstrapEnforcer.java
@@ -8,8 +8,11 @@
 package org.jguard.bootstrap;
 
 import java.io.File;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.nio.file.Path;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 /**
  * Bootstrap enforcement bridge for jGuard.
@@ -65,6 +68,21 @@ public final class BootstrapEnforcer {
    */
   private static volatile BiFunction<CallerContext, Path, SecurityException> fsWriteCallback;
 
+  /**
+   * Callback for network outbound enforcement.
+   *
+   * <p>Parameters: (callerContext) Returns: null if allowed, SecurityException if denied
+   */
+  private static volatile Function<CallerContext, SecurityException> networkOutboundCallback;
+
+  /**
+   * Callback for network listen enforcement.
+   *
+   * <p>Parameters: (callerContext, port) Returns: null if allowed, SecurityException if denied
+   */
+  private static volatile BiFunction<CallerContext, Integer, SecurityException>
+      networkListenCallback;
+
   /** Current enforcement mode. */
   private static volatile EnforcementMode mode = EnforcementMode.STRICT;
 
@@ -105,6 +123,34 @@ public final class BootstrapEnforcer {
       BiFunction<CallerContext, Path, SecurityException> callback) {
     fsWriteCallback = callback;
     LOG.debug("Filesystem write enforcement callback configured");
+  }
+
+  /**
+   * Configures the network outbound enforcement callback.
+   *
+   * <p>Called by the agent during initialization.
+   *
+   * @param callback function that takes (CallerContext) and returns null if allowed,
+   *     SecurityException if denied
+   */
+  public static void setNetworkOutboundCallback(
+      Function<CallerContext, SecurityException> callback) {
+    networkOutboundCallback = callback;
+    LOG.debug("Network outbound enforcement callback configured");
+  }
+
+  /**
+   * Configures the network listen enforcement callback.
+   *
+   * <p>Called by the agent during initialization.
+   *
+   * @param callback function that takes (CallerContext, Integer port) and returns null if allowed,
+   *     SecurityException if denied
+   */
+  public static void setNetworkListenCallback(
+      BiFunction<CallerContext, Integer, SecurityException> callback) {
+    networkListenCallback = callback;
+    LOG.debug("Network listen enforcement callback configured");
   }
 
   /**
@@ -336,6 +382,261 @@ public final class BootstrapEnforcer {
       throw se;
     } catch (Exception e) {
       handleEnforcementError("Enforcement callback failed", path, e);
+    }
+  }
+
+  // ========== NETWORK OUTBOUND ENFORCEMENT ==========
+
+  /**
+   * Called by ByteBuddy advice when a network connect operation is intercepted (host/port variant).
+   *
+   * @param host the host being connected to
+   * @param port the port being connected to
+   */
+  public static void onNetworkConnect(String host, int port) {
+    onNetworkConnectInternal(host, port);
+  }
+
+  /**
+   * Called by ByteBuddy advice when a network connect operation is intercepted (InetSocketAddress
+   * variant).
+   *
+   * @param address the socket address being connected to
+   */
+  public static void onNetworkConnect(InetSocketAddress address) {
+    if (address != null) {
+      String host = address.getHostString();
+      int port = address.getPort();
+      onNetworkConnectInternal(host, port);
+    }
+  }
+
+  /**
+   * Called by ByteBuddy advice when a network connect operation is intercepted (InetAddress
+   * variant).
+   *
+   * @param address the address being connected to
+   * @param port the port being connected to
+   */
+  public static void onNetworkConnect(InetAddress address, int port) {
+    if (address != null) {
+      onNetworkConnectInternal(address.getHostAddress(), port);
+    }
+  }
+
+  private static void onNetworkConnectInternal(String host, int port) {
+    // Prevent re-entrancy - if we're already in enforcement, allow
+    if (Boolean.TRUE.equals(IN_ENFORCEMENT.get())) {
+      return;
+    }
+
+    Function<CallerContext, SecurityException> callback = networkOutboundCallback;
+    if (callback == null) {
+      // Agent not initialized - allow (JVM bootstrap)
+      return;
+    }
+
+    try {
+      IN_ENFORCEMENT.set(true);
+      enforceNetworkOutbound(host, port, callback);
+    } finally {
+      IN_ENFORCEMENT.set(false);
+    }
+  }
+
+  private static void enforceNetworkOutbound(
+      String host, int port, Function<CallerContext, SecurityException> callback) {
+    CallerInfo caller;
+    try {
+      caller = determineCallerInfo();
+    } catch (Exception e) {
+      handleNetworkEnforcementError("Failed to determine caller", host, port, e);
+      return;
+    }
+
+    String callerPackage = caller.packageName();
+    String callerModule = caller.moduleName();
+
+    // Handle unknown caller based on mode
+    if ("unknown".equals(callerPackage)) {
+      handleUnknownNetworkCaller(host, port);
+      return;
+    }
+
+    try {
+      CallerContext context = caller.toContext();
+      SecurityException denial = callback.apply(context);
+
+      if (denial != null) {
+        // Access denied
+        if (logDenied) {
+          LOG.warn(
+              "DENIED network.outbound: package={}, module={}, target={}:{}",
+              callerPackage,
+              callerModule,
+              host,
+              port);
+        }
+        if (mode.blocksOnDenied()) {
+          throw denial;
+        }
+      } else {
+        // Access allowed
+        if (logAllowed) {
+          LOG.info(
+              "ALLOWED network.outbound: package={}, module={}, target={}:{}",
+              callerPackage,
+              callerModule,
+              host,
+              port);
+        }
+      }
+    } catch (SecurityException se) {
+      // Re-throw security exceptions
+      throw se;
+    } catch (Exception e) {
+      handleNetworkEnforcementError("Enforcement callback failed", host, port, e);
+    }
+  }
+
+  private static void handleUnknownNetworkCaller(String host, int port) {
+    // When the caller is "unknown", it typically means the call originated from JVM internals.
+    // We must allow these operations for the JVM to function, even in STRICT mode.
+    LOG.debug("Allowing network.outbound from unknown caller (JVM internal): {}:{}", host, port);
+  }
+
+  private static void handleNetworkEnforcementError(
+      String context, String host, int port, Exception e) {
+    String target = host + ":" + port;
+    if (mode.blocksOnError()) {
+      LOG.error("{}: {} - blocking network access to {}", context, e.getMessage(), target);
+      throw new SecurityException("jGuard: enforcement error - " + context + ": " + e.getMessage());
+    } else {
+      LOG.warn(
+          "{}: {} - allowing network access to {} (mode={})",
+          context,
+          e.getMessage(),
+          target,
+          mode);
+    }
+  }
+
+  // ========== NETWORK LISTEN ENFORCEMENT ==========
+
+  /**
+   * Called by ByteBuddy advice when a server socket bind operation is intercepted (port variant).
+   *
+   * @param port the port being bound to
+   */
+  public static void onNetworkListen(int port) {
+    onNetworkListenInternal(port);
+  }
+
+  /**
+   * Called by ByteBuddy advice when a server socket bind operation is intercepted
+   * (InetSocketAddress variant).
+   *
+   * @param address the socket address being bound to
+   */
+  public static void onNetworkListen(InetSocketAddress address) {
+    if (address != null) {
+      onNetworkListenInternal(address.getPort());
+    } else {
+      // null address means bind to any available port
+      onNetworkListenInternal(0);
+    }
+  }
+
+  private static void onNetworkListenInternal(int port) {
+    // Prevent re-entrancy - if we're already in enforcement, allow
+    if (Boolean.TRUE.equals(IN_ENFORCEMENT.get())) {
+      return;
+    }
+
+    BiFunction<CallerContext, Integer, SecurityException> callback = networkListenCallback;
+    if (callback == null) {
+      // Agent not initialized - allow (JVM bootstrap)
+      return;
+    }
+
+    try {
+      IN_ENFORCEMENT.set(true);
+      enforceNetworkListen(port, callback);
+    } finally {
+      IN_ENFORCEMENT.set(false);
+    }
+  }
+
+  private static void enforceNetworkListen(
+      int port, BiFunction<CallerContext, Integer, SecurityException> callback) {
+    CallerInfo caller;
+    try {
+      caller = determineCallerInfo();
+    } catch (Exception e) {
+      handleNetworkListenEnforcementError("Failed to determine caller", port, e);
+      return;
+    }
+
+    String callerPackage = caller.packageName();
+    String callerModule = caller.moduleName();
+
+    // Handle unknown caller based on mode
+    if ("unknown".equals(callerPackage)) {
+      handleUnknownNetworkListenCaller(port);
+      return;
+    }
+
+    try {
+      CallerContext context = caller.toContext();
+      SecurityException denial = callback.apply(context, port);
+
+      if (denial != null) {
+        // Access denied
+        if (logDenied) {
+          LOG.warn(
+              "DENIED network.listen: package={}, module={}, port={}",
+              callerPackage,
+              callerModule,
+              port);
+        }
+        if (mode.blocksOnDenied()) {
+          throw denial;
+        }
+      } else {
+        // Access allowed
+        if (logAllowed) {
+          LOG.info(
+              "ALLOWED network.listen: package={}, module={}, port={}",
+              callerPackage,
+              callerModule,
+              port);
+        }
+      }
+    } catch (SecurityException se) {
+      // Re-throw security exceptions
+      throw se;
+    } catch (Exception e) {
+      handleNetworkListenEnforcementError("Enforcement callback failed", port, e);
+    }
+  }
+
+  private static void handleUnknownNetworkListenCaller(int port) {
+    // When the caller is "unknown", it typically means the call originated from JVM internals.
+    // We must allow these operations for the JVM to function, even in STRICT mode.
+    LOG.debug("Allowing network.listen from unknown caller (JVM internal): port={}", port);
+  }
+
+  private static void handleNetworkListenEnforcementError(String context, int port, Exception e) {
+    if (mode.blocksOnError()) {
+      LOG.error("{}: {} - blocking network listen on port {}", context, e.getMessage(), port);
+      throw new SecurityException("jGuard: enforcement error - " + context + ": " + e.getMessage());
+    } else {
+      LOG.warn(
+          "{}: {} - allowing network listen on port {} (mode={})",
+          context,
+          e.getMessage(),
+          port,
+          mode);
     }
   }
 

--- a/agent/src/main/java/org/jguard/agent/JGuardAgent.java
+++ b/agent/src/main/java/org/jguard/agent/JGuardAgent.java
@@ -11,6 +11,7 @@ import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.none;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import java.io.File;
 import java.io.IOException;
@@ -275,6 +276,52 @@ public final class JGuardAgent {
 
       setWriteCallback.invoke(null, writeCallback);
 
+      // Set up network.outbound callback
+      java.lang.reflect.Method setNetworkCallback =
+          enforcerClass.getMethod("setNetworkOutboundCallback", java.util.function.Function.class);
+
+      java.util.function.Function<Object, SecurityException> networkCallback =
+          (bootstrapContext) -> {
+            try {
+              java.lang.reflect.Method getPackage = callerContextClass.getMethod("packageName");
+              java.lang.reflect.Method getModule = callerContextClass.getMethod("moduleName");
+              String packageName = (String) getPackage.invoke(bootstrapContext);
+              String moduleName = (String) getModule.invoke(bootstrapContext);
+
+              org.jguard.bootstrap.BootstrapEnforcer.CallerContext context =
+                  new org.jguard.bootstrap.BootstrapEnforcer.CallerContext(packageName, moduleName);
+
+              return enforcer.checkNetworkOutboundReturningException(context);
+            } catch (Exception e) {
+              throw new RuntimeException("Failed to extract caller context", e);
+            }
+          };
+
+      setNetworkCallback.invoke(null, networkCallback);
+
+      // Set up network.listen callback
+      java.lang.reflect.Method setNetworkListenCallback =
+          enforcerClass.getMethod("setNetworkListenCallback", java.util.function.BiFunction.class);
+
+      java.util.function.BiFunction<Object, Integer, SecurityException> networkListenCallback =
+          (bootstrapContext, port) -> {
+            try {
+              java.lang.reflect.Method getPackage = callerContextClass.getMethod("packageName");
+              java.lang.reflect.Method getModule = callerContextClass.getMethod("moduleName");
+              String packageName = (String) getPackage.invoke(bootstrapContext);
+              String moduleName = (String) getModule.invoke(bootstrapContext);
+
+              org.jguard.bootstrap.BootstrapEnforcer.CallerContext context =
+                  new org.jguard.bootstrap.BootstrapEnforcer.CallerContext(packageName, moduleName);
+
+              return enforcer.checkNetworkListenReturningException(context, port);
+            } catch (Exception e) {
+              throw new RuntimeException("Failed to extract caller context", e);
+            }
+          };
+
+      setNetworkListenCallback.invoke(null, networkListenCallback);
+
       // Set enforcement mode
       java.lang.reflect.Method setMode = enforcerClass.getMethod("setMode", modeClass);
       Object bootstrapMode = getEnumConstant(modeClass, config.mode().name());
@@ -293,11 +340,18 @@ public final class JGuardAgent {
   }
 
   private static void installInstrumentation(Instrumentation inst) {
-    LOG.debug("Installing filesystem instrumentation...");
+    LOG.debug("Installing instrumentation...");
+
+    // Check if retransformation is supported
+    if (!inst.isRetransformClassesSupported()) {
+      LOG.warn("Retransformation not supported - network instrumentation may not work");
+    }
 
     new AgentBuilder.Default()
         .disableClassFormatChanges()
         .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
+        .with(AgentBuilder.RedefinitionStrategy.DiscoveryStrategy.Reiterating.INSTANCE)
+        .with(AgentBuilder.TypeStrategy.Default.REDEFINE)
         .with(new LoggingListener())
         .ignore(none())
         // Instrument java.nio.file.Files - the primary NIO filesystem API
@@ -422,9 +476,84 @@ public final class JGuardAgent {
                     .visit(
                         Advice.to(FilesystemInterceptor.WriteStringPathAdvice.class)
                             .on(isConstructor().and(takesArgument(0, String.class)))))
+        // ========== NETWORK INSTRUMENTATION ==========
+        // Instrument java.net.Socket - the primary TCP socket API
+        .type(named("java.net.Socket"))
+        .transform(
+            (builder, typeDescription, classLoader, module, protectionDomain) ->
+                builder
+                    // Socket(String host, int port)
+                    .visit(
+                        Advice.to(NetworkInterceptor.SocketHostPortAdvice.class)
+                            .on(
+                                isConstructor()
+                                    .and(takesArgument(0, String.class))
+                                    .and(takesArgument(1, int.class))
+                                    .and(takesArguments(2))))
+                    // Socket(InetAddress address, int port)
+                    .visit(
+                        Advice.to(NetworkInterceptor.SocketInetAddressPortAdvice.class)
+                            .on(
+                                isConstructor()
+                                    .and(takesArgument(0, java.net.InetAddress.class))
+                                    .and(takesArgument(1, int.class))
+                                    .and(takesArguments(2))))
+                    // Socket.connect(SocketAddress, int timeout)
+                    .visit(
+                        Advice.to(NetworkInterceptor.SocketConnectAdvice.class)
+                            .on(
+                                named("connect")
+                                    .and(takesArgument(0, java.net.SocketAddress.class)))))
+        // Instrument java.nio.channels.SocketChannel - NIO socket API
+        .type(named("java.nio.channels.SocketChannel"))
+        .transform(
+            (builder, typeDescription, classLoader, module, protectionDomain) ->
+                builder.visit(
+                    Advice.to(NetworkInterceptor.SocketChannelConnectAdvice.class)
+                        .on(named("connect").and(takesArgument(0, java.net.SocketAddress.class)))))
+        // ========== SERVER SOCKET INSTRUMENTATION (network.listen) ==========
+        // Instrument java.net.ServerSocket - the primary server socket API
+        .type(named("java.net.ServerSocket"))
+        .transform(
+            (builder, typeDescription, classLoader, module, protectionDomain) ->
+                builder
+                    // ServerSocket(int port)
+                    .visit(
+                        Advice.to(NetworkInterceptor.ServerSocketPortAdvice.class)
+                            .on(
+                                isConstructor()
+                                    .and(takesArgument(0, int.class))
+                                    .and(takesArguments(1))))
+                    // ServerSocket(int port, int backlog)
+                    .visit(
+                        Advice.to(NetworkInterceptor.ServerSocketPortAdvice.class)
+                            .on(
+                                isConstructor()
+                                    .and(takesArgument(0, int.class))
+                                    .and(takesArgument(1, int.class))
+                                    .and(takesArguments(2))))
+                    // ServerSocket(int port, int backlog, InetAddress bindAddr)
+                    .visit(
+                        Advice.to(NetworkInterceptor.ServerSocketPortAdvice.class)
+                            .on(
+                                isConstructor()
+                                    .and(takesArgument(0, int.class))
+                                    .and(takesArgument(1, int.class))
+                                    .and(takesArgument(2, java.net.InetAddress.class))))
+                    // ServerSocket.bind(SocketAddress)
+                    .visit(
+                        Advice.to(NetworkInterceptor.ServerSocketBindAdvice.class)
+                            .on(named("bind").and(takesArgument(0, java.net.SocketAddress.class)))))
+        // Instrument java.nio.channels.ServerSocketChannel - NIO server socket API
+        .type(named("java.nio.channels.ServerSocketChannel"))
+        .transform(
+            (builder, typeDescription, classLoader, module, protectionDomain) ->
+                builder.visit(
+                    Advice.to(NetworkInterceptor.ServerSocketChannelBindAdvice.class)
+                        .on(named("bind").and(takesArgument(0, java.net.SocketAddress.class)))))
         .installOn(inst);
 
-    LOG.debug("Filesystem instrumentation installed");
+    LOG.debug("Instrumentation installed");
   }
 
   /**
@@ -457,7 +586,12 @@ public final class JGuardAgent {
     @Override
     public void onDiscovery(
         String typeName, ClassLoader classLoader, JavaModule module, boolean loaded) {
-      // Not logged to avoid noise
+      // Log discovery of classes we're interested in
+      if (typeName.contains("Socket")
+          || typeName.contains("ServerSocket")
+          || typeName.contains("Files")) {
+        LOG.debug("Discovered: {} (loaded={})", typeName, loaded);
+      }
     }
 
     @Override
@@ -467,7 +601,7 @@ public final class JGuardAgent {
         JavaModule module,
         boolean loaded,
         DynamicType dynamicType) {
-      LOG.debug("Transformed: {}", typeDescription.getName());
+      LOG.info("Transformed: {} (loaded={})", typeDescription.getName(), loaded);
     }
 
     @Override
@@ -476,7 +610,11 @@ public final class JGuardAgent {
         ClassLoader classLoader,
         JavaModule module,
         boolean loaded) {
-      // Not logged to avoid noise
+      // Log ignored classes we're interested in
+      String name = typeDescription.getName();
+      if (name.contains("Socket") || name.equals("java.nio.file.Files")) {
+        LOG.debug("Ignored: {} (loaded={})", name, loaded);
+      }
     }
 
     @Override
@@ -486,7 +624,10 @@ public final class JGuardAgent {
         JavaModule module,
         boolean loaded,
         Throwable throwable) {
-      LOG.warn("Error transforming: {}", typeName, throwable);
+      LOG.error("Error transforming: {} - {}", typeName, throwable.getMessage());
+      if (typeName.contains("Socket")) {
+        LOG.error("Socket transformation error details:", throwable);
+      }
     }
 
     @Override

--- a/agent/src/main/java/org/jguard/agent/NetworkInterceptor.java
+++ b/agent/src/main/java/org/jguard/agent/NetworkInterceptor.java
@@ -1,0 +1,206 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The jGuard Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.jguard.agent;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import net.bytebuddy.asm.Advice;
+import org.jguard.bootstrap.BootstrapEnforcer;
+
+/**
+ * ByteBuddy advice for intercepting network outbound operations.
+ *
+ * <p>This class contains static advice methods that are woven into JDK network classes to enforce
+ * network.outbound entitlements.
+ *
+ * <p><b>Important:</b> All advice methods MUST only reference classes from the {@code
+ * org.jguard.bootstrap} package and JDK classes. The bootstrap package is injected into the
+ * bootstrap classloader, making it visible to transformed JDK classes. Any reference to
+ * non-bootstrap classes will cause {@link NoClassDefFoundError} at runtime.
+ */
+public final class NetworkInterceptor {
+
+  private NetworkInterceptor() {
+    // Advice class
+  }
+
+  /**
+   * Advice for Socket.connect(SocketAddress) and similar methods.
+   *
+   * <p>Applied to: Socket.connect(SocketAddress, int)
+   */
+  public static class SocketConnectAdvice {
+
+    private SocketConnectAdvice() {}
+
+    /**
+     * Intercepts method entry to enforce network.outbound policy.
+     *
+     * @param address the socket address being connected to
+     */
+    @Advice.OnMethodEnter
+    public static void onEnter(@Advice.Argument(0) SocketAddress address) {
+      if (address instanceof InetSocketAddress inetAddr) {
+        BootstrapEnforcer.onNetworkConnect(inetAddr);
+      }
+    }
+  }
+
+  /**
+   * Advice for Socket constructors that take host/port.
+   *
+   * <p>Applied to: Socket(String, int), Socket(InetAddress, int)
+   */
+  public static class SocketHostPortAdvice {
+
+    private SocketHostPortAdvice() {}
+
+    /**
+     * Intercepts method entry to enforce network.outbound policy.
+     *
+     * @param host the host being connected to
+     * @param port the port being connected to
+     */
+    @Advice.OnMethodEnter
+    public static void onEnter(@Advice.Argument(0) String host, @Advice.Argument(1) int port) {
+      BootstrapEnforcer.onNetworkConnect(host, port);
+    }
+  }
+
+  /**
+   * Advice for Socket constructors that take InetAddress/port.
+   *
+   * <p>Applied to: Socket(InetAddress, int)
+   */
+  public static class SocketInetAddressPortAdvice {
+
+    private SocketInetAddressPortAdvice() {}
+
+    /**
+     * Intercepts method entry to enforce network.outbound policy.
+     *
+     * @param address the address being connected to
+     * @param port the port being connected to
+     */
+    @Advice.OnMethodEnter
+    public static void onEnter(
+        @Advice.Argument(0) InetAddress address, @Advice.Argument(1) int port) {
+      BootstrapEnforcer.onNetworkConnect(address, port);
+    }
+  }
+
+  /**
+   * Advice for SocketChannel.connect(SocketAddress).
+   *
+   * <p>Applied to: SocketChannel.connect(SocketAddress)
+   */
+  public static class SocketChannelConnectAdvice {
+
+    private SocketChannelConnectAdvice() {}
+
+    /**
+     * Intercepts method entry to enforce network.outbound policy.
+     *
+     * @param address the socket address being connected to
+     */
+    @Advice.OnMethodEnter
+    public static void onEnter(@Advice.Argument(0) SocketAddress address) {
+      if (address instanceof InetSocketAddress inetAddr) {
+        BootstrapEnforcer.onNetworkConnect(inetAddr);
+      }
+    }
+  }
+
+  /**
+   * Advice for URL.openConnection() and HttpClient connections.
+   *
+   * <p>Applied to: URL.openConnection(), HttpURLConnection.connect()
+   *
+   * <p>Note: URL.openConnection() returns a URLConnection but doesn't actually connect. The actual
+   * connection happens in URLConnection.connect() or when reading/writing. For HTTP, we intercept
+   * at the Socket level which catches all connections.
+   */
+  public static class UrlConnectionAdvice {
+
+    private UrlConnectionAdvice() {}
+
+    // This advice is a placeholder - actual enforcement happens at the Socket level
+    // since all HTTP connections eventually go through Socket.connect()
+  }
+
+  // ========== NETWORK LISTEN (SERVER SOCKET) ADVICE ==========
+
+  /**
+   * Advice for ServerSocket constructors that take port.
+   *
+   * <p>Applied to: ServerSocket(int port), ServerSocket(int port, int backlog)
+   */
+  public static class ServerSocketPortAdvice {
+
+    private ServerSocketPortAdvice() {}
+
+    /**
+     * Intercepts method entry to enforce network.listen policy.
+     *
+     * @param port the port being bound to
+     */
+    @Advice.OnMethodEnter
+    public static void onEnter(@Advice.Argument(0) int port) {
+      BootstrapEnforcer.onNetworkListen(port);
+    }
+  }
+
+  /**
+   * Advice for ServerSocket.bind(SocketAddress).
+   *
+   * <p>Applied to: ServerSocket.bind(SocketAddress), ServerSocket.bind(SocketAddress, int)
+   */
+  public static class ServerSocketBindAdvice {
+
+    private ServerSocketBindAdvice() {}
+
+    /**
+     * Intercepts method entry to enforce network.listen policy.
+     *
+     * @param address the socket address being bound to
+     */
+    @Advice.OnMethodEnter
+    public static void onEnter(@Advice.Argument(0) SocketAddress address) {
+      if (address instanceof InetSocketAddress inetAddr) {
+        BootstrapEnforcer.onNetworkListen(inetAddr);
+      }
+    }
+  }
+
+  /**
+   * Advice for ServerSocketChannel.bind(SocketAddress).
+   *
+   * <p>Applied to: ServerSocketChannel.bind(SocketAddress), ServerSocketChannel.bind(SocketAddress,
+   * int)
+   */
+  public static class ServerSocketChannelBindAdvice {
+
+    private ServerSocketChannelBindAdvice() {}
+
+    /**
+     * Intercepts method entry to enforce network.listen policy.
+     *
+     * @param address the socket address being bound to
+     */
+    @Advice.OnMethodEnter
+    public static void onEnter(@Advice.Argument(0) SocketAddress address) {
+      if (address instanceof InetSocketAddress inetAddr) {
+        BootstrapEnforcer.onNetworkListen(inetAddr);
+      } else if (address == null) {
+        // null means bind to any available port
+        BootstrapEnforcer.onNetworkListen(0);
+      }
+    }
+  }
+}

--- a/agent/src/main/java/org/jguard/agent/PolicyEnforcer.java
+++ b/agent/src/main/java/org/jguard/agent/PolicyEnforcer.java
@@ -144,6 +144,90 @@ public final class PolicyEnforcer {
   }
 
   /**
+   * Checks if the caller is entitled to make outbound network connections.
+   *
+   * @param context the caller context containing package and module information
+   * @return null if allowed, SecurityException if denied
+   */
+  public SecurityException checkNetworkOutboundReturningException(CallerContext context) {
+    String callerPackage = context.packageName();
+    String callerModule = context.moduleName();
+
+    // First, verify module identity
+    if (!isValidModule(callerModule)) {
+      LOG.debug("Module mismatch: caller module={}, expected module={}", callerModule, moduleName);
+      return deniedModuleMismatch(callerPackage, callerModule, "network.outbound");
+    }
+
+    String cacheKey = callerPackage + ":" + callerModule + ":network.outbound";
+    Boolean cached = decisionCache.get(cacheKey);
+    if (cached != null) {
+      return cached ? null : denied(callerPackage, "network.outbound", "outbound connection");
+    }
+
+    boolean allowed = isAllowedNetworkOutbound(callerPackage);
+    decisionCache.put(cacheKey, allowed);
+
+    return allowed ? null : denied(callerPackage, "network.outbound", "outbound connection");
+  }
+
+  /**
+   * Checks if the caller is entitled to make outbound network connections. Throws if denied.
+   *
+   * @param context the caller context containing package and module information
+   * @throws SecurityException if access is denied
+   */
+  public void checkNetworkOutbound(CallerContext context) {
+    SecurityException denial = checkNetworkOutboundReturningException(context);
+    if (denial != null) {
+      throw denial;
+    }
+  }
+
+  /**
+   * Checks if the caller is entitled to listen on a server socket.
+   *
+   * @param context the caller context containing package and module information
+   * @param port the port being bound to
+   * @return null if allowed, SecurityException if denied
+   */
+  public SecurityException checkNetworkListenReturningException(CallerContext context, int port) {
+    String callerPackage = context.packageName();
+    String callerModule = context.moduleName();
+
+    // First, verify module identity
+    if (!isValidModule(callerModule)) {
+      LOG.debug("Module mismatch: caller module={}, expected module={}", callerModule, moduleName);
+      return deniedModuleMismatch(callerPackage, callerModule, "network.listen");
+    }
+
+    String cacheKey = callerPackage + ":" + callerModule + ":network.listen:" + port;
+    Boolean cached = decisionCache.get(cacheKey);
+    if (cached != null) {
+      return cached ? null : denied(callerPackage, "network.listen", "port " + port);
+    }
+
+    boolean allowed = isAllowedNetworkListen(callerPackage, port);
+    decisionCache.put(cacheKey, allowed);
+
+    return allowed ? null : denied(callerPackage, "network.listen", "port " + port);
+  }
+
+  /**
+   * Checks if the caller is entitled to listen on a server socket. Throws if denied.
+   *
+   * @param context the caller context containing package and module information
+   * @param port the port being bound to
+   * @throws SecurityException if access is denied
+   */
+  public void checkNetworkListen(CallerContext context, int port) {
+    SecurityException denial = checkNetworkListenReturningException(context, port);
+    if (denial != null) {
+      throw denial;
+    }
+  }
+
+  /**
    * Validates that the caller's module is allowed by the policy.
    *
    * <p>The policy is compiled for a specific module. We allow:
@@ -178,6 +262,63 @@ public final class PolicyEnforcer {
 
   private boolean isAllowedFsWrite(String callerPackage, Path path) {
     return isAllowedFsOperation(callerPackage, path, "fs.write");
+  }
+
+  private boolean isAllowedNetworkOutbound(String callerPackage) {
+    // Check all entitlements that apply to this caller
+    for (Entitlement entitlement : policy.entitlements()) {
+      if (!entitlement.capability().name().equals("network.outbound")) {
+        continue;
+      }
+      if (!subjectMatches(entitlement.subject(), callerPackage)) {
+        continue;
+      }
+
+      // network.outbound takes no arguments - if the subject matches, it's allowed
+      LOG.debug("network.outbound allowed: package={}, entitlement={}", callerPackage, entitlement);
+      return true;
+    }
+
+    LOG.debug("network.outbound denied: package={}", callerPackage);
+    return false;
+  }
+
+  private boolean isAllowedNetworkListen(String callerPackage, int port) {
+    // Check all entitlements that apply to this caller
+    for (Entitlement entitlement : policy.entitlements()) {
+      if (!entitlement.capability().name().equals("network.listen")) {
+        continue;
+      }
+      if (!subjectMatches(entitlement.subject(), callerPackage)) {
+        continue;
+      }
+
+      List<CapabilityArgument> args = entitlement.capability().arguments();
+      if (args.isEmpty()) {
+        // network.listen with no arguments - allows any port
+        LOG.debug(
+            "network.listen allowed (any port): package={}, port={}, entitlement={}",
+            callerPackage,
+            port,
+            entitlement);
+        return true;
+      } else if (args.size() == 1) {
+        // network.listen(port) - check specific port
+        long allowedPort = ((CapabilityArgument.IntegerArg) args.get(0)).value();
+        if (port == allowedPort || port == 0) {
+          // Port 0 means "any available port" - we allow it if they have any listen entitlement
+          LOG.debug(
+              "network.listen allowed (port match): package={}, port={}, entitlement={}",
+              callerPackage,
+              port,
+              entitlement);
+          return true;
+        }
+      }
+    }
+
+    LOG.debug("network.listen denied: package={}, port={}", callerPackage, port);
+    return false;
   }
 
   private boolean isAllowedFsOperation(String callerPackage, Path path, String capability) {
@@ -267,7 +408,10 @@ public final class PolicyEnforcer {
   private void indexFsEntitlements() {
     for (Entitlement entitlement : policy.entitlements()) {
       String capName = entitlement.capability().name();
-      if (capName.equals("fs.read") || capName.equals("fs.write")) {
+      if (capName.equals("fs.read")
+          || capName.equals("fs.write")
+          || capName.equals("network.outbound")
+          || capName.equals("network.listen")) {
         LOG.debug("Indexed {} entitlement: {}", capName, entitlement);
       }
     }

--- a/policy/src/main/java/org/jguard/policy/validation/PolicyValidator.java
+++ b/policy/src/main/java/org/jguard/policy/validation/PolicyValidator.java
@@ -42,12 +42,12 @@ public final class PolicyValidator {
   // For v0.1.0: fs.read(root, glob) and network.outbound
   private static final Map<String, CapabilitySignature> KNOWN_CAPABILITIES =
       Map.of(
-          "fs.read", new CapabilitySignature(2, List.of(ArgType.STRING, ArgType.STRING)),
-          "fs.write", new CapabilitySignature(2, List.of(ArgType.STRING, ArgType.STRING)),
-          "network.outbound", new CapabilitySignature(0, List.of()),
-          "network.listen", new CapabilitySignature(1, List.of(ArgType.INTEGER)),
-          "threads.spawn", new CapabilitySignature(0, List.of()),
-          "native.load", new CapabilitySignature(0, List.of()));
+          "fs.read", new CapabilitySignature(2, 2, List.of(ArgType.STRING, ArgType.STRING)),
+          "fs.write", new CapabilitySignature(2, 2, List.of(ArgType.STRING, ArgType.STRING)),
+          "network.outbound", new CapabilitySignature(0, 0, List.of()),
+          "network.listen", new CapabilitySignature(0, 1, List.of(ArgType.INTEGER)),
+          "threads.spawn", new CapabilitySignature(0, 0, List.of()),
+          "native.load", new CapabilitySignature(0, 0, List.of()));
 
   private final String sourcePath;
   private final List<CompilationResult.Diagnostic> diagnostics = new ArrayList<>();
@@ -136,19 +136,37 @@ public final class PolicyValidator {
     }
 
     // Check argument count
-    int expectedCount = signature.argCount();
+    int minCount = signature.minArgCount();
+    int maxCount = signature.maxArgCount();
     int actualCount = capability.arguments().size();
-    if (actualCount != expectedCount) {
-      if (expectedCount == 0) {
-        error(
-            "Capability '" + name + "' takes no arguments, but " + actualCount + " provided",
-            location);
+
+    if (actualCount < minCount || actualCount > maxCount) {
+      if (minCount == maxCount) {
+        // Fixed argument count
+        if (minCount == 0) {
+          error(
+              "Capability '" + name + "' takes no arguments, but " + actualCount + " provided",
+              location);
+        } else {
+          error(
+              "Capability '"
+                  + name
+                  + "' requires "
+                  + minCount
+                  + " argument(s), but "
+                  + actualCount
+                  + " provided",
+              location);
+        }
       } else {
+        // Variable argument count
         error(
             "Capability '"
                 + name
                 + "' requires "
-                + expectedCount
+                + minCount
+                + " to "
+                + maxCount
                 + " argument(s), but "
                 + actualCount
                 + " provided",
@@ -157,7 +175,7 @@ public final class PolicyValidator {
       return;
     }
 
-    // Check argument types
+    // Check argument types (only for provided arguments)
     List<Argument> args = capability.arguments();
     for (int i = 0; i < args.size(); i++) {
       Argument arg = args.get(i);
@@ -266,7 +284,7 @@ public final class PolicyValidator {
     return JAVA_KEYWORDS.contains(s);
   }
 
-  private record CapabilitySignature(int argCount, List<ArgType> argTypes) {}
+  private record CapabilitySignature(int minArgCount, int maxArgCount, List<ArgType> argTypes) {}
 
   private enum ArgType {
     STRING,

--- a/samples/sandbox-demo/src/main/java/module-info.jguard
+++ b/samples/sandbox-demo/src/main/java/module-info.jguard
@@ -18,6 +18,9 @@ security module org.jguard.samples.sandbox {
     // Grant network outbound to specific packages
     entitle org.jguard.samples.sandbox.net to network.outbound;
 
+    // Grant network listen to specific packages
+    entitle org.jguard.samples.sandbox.net to network.listen;
+
     // Grant thread spawning to the worker package hierarchy
     entitle org.jguard.samples.sandbox.worker.. to threads.spawn;
 

--- a/samples/sandbox-demo/src/main/java/org/jguard/samples/sandbox/Main.java
+++ b/samples/sandbox-demo/src/main/java/org/jguard/samples/sandbox/Main.java
@@ -11,9 +11,13 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.jguard.core.JGuard;
+import org.jguard.samples.sandbox.net.NetworkClient;
+import org.jguard.samples.sandbox.net.NetworkServer;
 
 /**
  * Demonstrates jGuard capability-based security enforcement.
@@ -24,6 +28,9 @@ import org.jguard.core.JGuard;
  * <ul>
  *   <li>fs.read("src", "**\/*") - filesystem read access to source directory
  *   <li>fs.write("build/test-output", "**") - filesystem write access to test output directory
+ *   <li>network.outbound - outbound network connections (from org.jguard.samples.sandbox.net
+ *       package)
+ *   <li>network.listen - server socket binding (from org.jguard.samples.sandbox.net package)
  * </ul>
  *
  * <h2>Running without the agent (no enforcement):</h2>
@@ -81,6 +88,22 @@ public final class Main {
 
     // Test 8: Write to /tmp using FileOutputStream (NOT ENTITLED)
     demonstrateUnentitledFileOutputStreamAccess();
+
+    // === NETWORK TESTS ===
+    System.out.println("--- NETWORK TESTS ---");
+    System.out.println();
+
+    // Test 9: Network connection from entitled package (ENTITLED)
+    demonstrateEntitledNetworkAccess();
+
+    // Test 10: Network connection from non-entitled package (NOT ENTITLED)
+    demonstrateUnentitledNetworkAccess();
+
+    // Test 11: Server socket from entitled package (ENTITLED)
+    demonstrateEntitledNetworkListenAccess();
+
+    // Test 12: Server socket from non-entitled package (NOT ENTITLED)
+    demonstrateUnentitledNetworkListenAccess();
   }
 
   /**
@@ -283,6 +306,113 @@ public final class Main {
       System.out.println("  (This should be BLOCKED when running with the agent!)");
       // Clean up
       testFile.delete();
+    } catch (SecurityException e) {
+      System.out.println("  BLOCKED (expected): " + e.getMessage());
+    } catch (IOException e) {
+      System.out.println("  ERROR: " + e.getMessage());
+    }
+
+    System.out.println();
+  }
+
+  /**
+   * Demonstrates network connection from entitled package.
+   *
+   * <p>This operation IS entitled because it's called from the .net package which has
+   * network.outbound entitlement.
+   */
+  private static void demonstrateEntitledNetworkAccess() {
+    System.out.println("[ENTITLED] network.outbound (from .net package)");
+    System.out.println("  Attempting to connect to localhost:80...");
+
+    try {
+      // This call is made FROM the NetworkClient class in the .net package
+      // which HAS network.outbound entitlement
+      boolean connected = NetworkClient.tryConnect("localhost", 80);
+      if (connected) {
+        System.out.println("  SUCCESS: Connected to localhost:80");
+      } else {
+        System.out.println("  SUCCESS: Connection attempt allowed (port closed or unreachable)");
+      }
+    } catch (SecurityException e) {
+      System.out.println("  BLOCKED (unexpected): " + e.getMessage());
+    }
+
+    System.out.println();
+  }
+
+  /**
+   * Demonstrates network connection from non-entitled package.
+   *
+   * <p>This operation is NOT entitled because Main is in the sandbox package, not the .net package.
+   * It should be blocked when the agent is active.
+   */
+  private static void demonstrateUnentitledNetworkAccess() {
+    System.out.println("[NOT ENTITLED] network.outbound (from main package)");
+    System.out.println("  Attempting to connect to localhost:80 directly...");
+
+    try {
+      // This call is made FROM this class (Main) which is in the .sandbox package
+      // which does NOT have network.outbound entitlement
+      try (Socket socket = new Socket("localhost", 80)) {
+        System.out.println("  SUCCESS: Connected to localhost:80 (unexpected!)");
+        System.out.println("  (This should be BLOCKED when running with the agent!)");
+      }
+    } catch (SecurityException e) {
+      System.out.println("  BLOCKED (expected): " + e.getMessage());
+    } catch (IOException e) {
+      // Connection refused or similar is expected if port is not open
+      System.out.println("  SUCCESS: Connection attempt allowed (port closed or unreachable)");
+      System.out.println("  (This should be BLOCKED when running with the agent!)");
+    }
+
+    System.out.println();
+  }
+
+  /**
+   * Demonstrates server socket binding from entitled package.
+   *
+   * <p>This operation IS entitled because it's called from the .net package which has network.listen
+   * entitlement.
+   */
+  private static void demonstrateEntitledNetworkListenAccess() {
+    System.out.println("[ENTITLED] network.listen (from .net package)");
+    System.out.println("  Attempting to bind ServerSocket to port 0 (any available)...");
+
+    try {
+      // This call is made FROM the NetworkServer class in the .net package
+      // which HAS network.listen entitlement
+      int boundPort = NetworkServer.tryListen(0);
+      if (boundPort > 0) {
+        System.out.println("  SUCCESS: Bound to port " + boundPort);
+      } else {
+        System.out.println("  FAILED: Could not bind to any port (unexpected)");
+      }
+    } catch (SecurityException e) {
+      System.out.println("  BLOCKED (unexpected): " + e.getMessage());
+    }
+
+    System.out.println();
+  }
+
+  /**
+   * Demonstrates server socket binding from non-entitled package.
+   *
+   * <p>This operation is NOT entitled because Main is in the sandbox package, not the .net package.
+   * It should be blocked when the agent is active.
+   */
+  private static void demonstrateUnentitledNetworkListenAccess() {
+    System.out.println("[NOT ENTITLED] network.listen (from main package)");
+    System.out.println("  Attempting to bind ServerSocket to port 0 directly...");
+
+    try {
+      // This call is made FROM this class (Main) which is in the .sandbox package
+      // which does NOT have network.listen entitlement
+      try (ServerSocket serverSocket = new ServerSocket(0)) {
+        int port = serverSocket.getLocalPort();
+        System.out.println("  SUCCESS: Bound to port " + port + " (unexpected!)");
+        System.out.println("  (This should be BLOCKED when running with the agent!)");
+      }
     } catch (SecurityException e) {
       System.out.println("  BLOCKED (expected): " + e.getMessage());
     } catch (IOException e) {

--- a/samples/sandbox-demo/src/main/java/org/jguard/samples/sandbox/net/NetworkClient.java
+++ b/samples/sandbox-demo/src/main/java/org/jguard/samples/sandbox/net/NetworkClient.java
@@ -8,44 +8,33 @@
 package org.jguard.samples.sandbox.net;
 
 import java.io.IOException;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.time.Duration;
+import java.net.Socket;
 
 /**
- * Network client entitled to make outbound connections.
+ * Network client that is entitled to make outbound connections.
  *
- * <p>This class is in the {@code org.jguard.samples.sandbox.net} package,
- * which is entitled to {@code network.outbound} capability.
+ * <p>This class is in the {@code org.jguard.samples.sandbox.net} package, which is granted
+ * {@code network.outbound} capability in the module policy.
  */
 public final class NetworkClient {
 
-    private final HttpClient client;
+  private NetworkClient() {}
 
-    public NetworkClient() {
-        this.client = HttpClient.newBuilder()
-            .connectTimeout(Duration.ofSeconds(10))
-            .build();
+  /**
+   * Attempts to establish a TCP connection to the specified host and port.
+   *
+   * @param host the host to connect to
+   * @param port the port to connect to
+   * @return true if connection was successful
+   * @throws SecurityException if the operation is blocked by jGuard
+   */
+  public static boolean tryConnect(String host, int port) {
+    try (Socket socket = new Socket(host, port)) {
+      // Connection successful
+      return true;
+    } catch (IOException e) {
+      // Connection failed (network issue, not security)
+      return false;
     }
-
-    /**
-     * Fetches the HTTP status code from a URL.
-     *
-     * @param url the URL to fetch
-     * @return the HTTP status code
-     * @throws IOException if the request fails
-     * @throws InterruptedException if the request is interrupted
-     */
-    public int fetchStatus(String url) throws IOException, InterruptedException {
-        HttpRequest request = HttpRequest.newBuilder()
-            .uri(URI.create(url))
-            .GET()
-            .timeout(Duration.ofSeconds(10))
-            .build();
-
-        HttpResponse<Void> response = client.send(request, HttpResponse.BodyHandlers.discarding());
-        return response.statusCode();
-    }
+  }
 }

--- a/samples/sandbox-demo/src/main/java/org/jguard/samples/sandbox/net/NetworkServer.java
+++ b/samples/sandbox-demo/src/main/java/org/jguard/samples/sandbox/net/NetworkServer.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The jGuard Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.jguard.samples.sandbox.net;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+/**
+ * Network server that is entitled to listen on server sockets.
+ *
+ * <p>This class is in the {@code org.jguard.samples.sandbox.net} package, which is granted
+ * {@code network.listen} capability in the module policy.
+ */
+public final class NetworkServer {
+
+  private NetworkServer() {}
+
+  /**
+   * Attempts to create a ServerSocket and bind to a port.
+   *
+   * @param port the port to bind to (0 for any available port)
+   * @return the bound port number if successful, -1 if failed
+   * @throws SecurityException if the operation is blocked by jGuard
+   */
+  public static int tryListen(int port) {
+    try (ServerSocket serverSocket = new ServerSocket(port)) {
+      // Successfully bound to the port
+      return serverSocket.getLocalPort();
+    } catch (IOException e) {
+      // Bind failed (port in use or other network issue)
+      return -1;
+    }
+  }
+}

--- a/samples/sandbox-demo/src/test/java/org/jguard/samples/sandbox/EntitlementTest.java
+++ b/samples/sandbox-demo/src/test/java/org/jguard/samples/sandbox/EntitlementTest.java
@@ -79,16 +79,16 @@ class EntitlementTest {
 
         @Test
         @DisplayName("net package can make outbound connections (entitled)")
-        void netPackageCanConnect() throws Exception {
+        void netPackageCanConnect() {
             // Given: org.jguard.samples.sandbox.net is entitled to network.outbound
-            NetworkClient client = new NetworkClient();
+            // When: we attempt an outbound connection
+            // Note: tryConnect returns false if connection fails (port closed), true if succeeds
+            // Either result means the connection attempt was ALLOWED by jGuard
+            boolean result = NetworkClient.tryConnect("localhost", 80);
 
-            // When: we make an outbound request
-            // Note: This test requires network access; skip in isolated environments
-            int status = client.fetchStatus("https://httpbin.org/status/200");
-
-            // Then: operation succeeds
-            assertThat(status).isEqualTo(200);
+            // Then: operation completes without SecurityException
+            // (connection may fail due to port being closed, but that's not a security denial)
+            assertThat(result).isIn(true, false);
         }
 
         // TODO: Once enforcement is implemented, add tests for denied operations:


### PR DESCRIPTION
 ## Description
  Implement network enforcement for outbound connections and server socket
  binding, completing milestones M4 and M4.1.

  network.outbound:
  - Grants permission for outbound TCP connections
  - Instruments Socket constructors, Socket.connect(), and SocketChannel.connect()
  - Uses DiscoveryStrategy.Reiterating for bootstrap class retransformation

  network.listen:
  - Grants permission for server socket binding
  - Supports two forms:
    - network.listen (no args) - allows any port
    - network.listen(port) - allows specific port only
  - Instruments ServerSocket constructors, ServerSocket.bind(), and ServerSocketChannel.bind()

  Implementation:
  - BootstrapEnforcer: callbacks for network connect/listen enforcement
  - PolicyEnforcer: checkNetworkOutbound() and checkNetworkListen(port)
  - NetworkInterceptor: ByteBuddy advice classes for Socket/ServerSocket
  - JGuardAgent: instrumentation setup with retransformation support
  - PolicyValidator: updated to support optional arguments (0-1 for listen)

  Testing:
  - sandbox-demo updated with entitled/non-entitled network tests
  - Verified blocking of unauthorized outbound connections
  - Verified blocking of unauthorized server socket creation
