### PR TITLE
Refactor enforcement to category-based dispatch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,260 @@
+# Contributing to jGuard
+
+This guide explains how to contribute to jGuard, with a focus on adding new capabilities.
+
+## Architecture Overview
+
+jGuard uses a two-module architecture for proper classloader handling:
+
+```
+ByteBuddy Advice (interceptors)
+       │
+       ▼
+BootstrapEnforcer.dispatch(Operation, arg0, arg1)  ← bootstrap classloader
+       │
+       ▼ (single callback)
+EnforcementCallback.check(CallerContext, Operation, arg0, arg1)  ← agent classloader
+       │
+       ▼
+PolicyEnforcer.check()  ← category-based dispatch
+```
+
+### Modules
+
+| Module | Purpose | Classloader |
+|--------|---------|-------------|
+| `agent-bootstrap` | Classes injected into bootstrap classloader | Bootstrap |
+| `agent` | ByteBuddy instrumentation and policy enforcement | System/App |
+| `policy` | Policy model and compilation | System/App |
+| `core` | Public API for applications | System/App |
+
+### Key Classes
+
+| Class | Location | Purpose |
+|-------|----------|---------|
+| `Operation` | agent-bootstrap | Enum with capability name and category |
+| `Operation.Category` | agent-bootstrap | Determines matching logic (SIMPLE, PORT, etc.) |
+| `BootstrapEnforcer` | agent-bootstrap | Entry points called by advice |
+| `PolicyEnforcer` | agent | Category-based policy evaluation |
+| `*Interceptor` | agent | ByteBuddy advice classes |
+
+## Categories
+
+Categories determine how capabilities match against policy. **Using an existing category means zero changes to PolicyEnforcer.**
+
+| Category | Policy Args | Matching Logic | Examples |
+|----------|-------------|----------------|----------|
+| `SIMPLE` | None | Subject match only | `network.outbound`, `threads.create` |
+| `PORT` | Optional `(port)` | No args = any port, with arg = specific port | `network.listen` |
+| `TARGET_PATTERN` | Optional `(pattern)` | No args = any target, with arg = pattern match | `reflect.invoke`, `native.load` |
+| `FILESYSTEM` | Required `(root, glob)` | Path must match root + glob | `fs.read`, `fs.write` |
+
+## Adding a New Capability
+
+### If Using an Existing Category (Easiest)
+
+For capabilities like `threads.create` that use the `SIMPLE` category:
+
+**Only 4 changes needed, 0 lines in PolicyEnforcer!**
+
+#### Step 1: Add to Operation Enum (1 line)
+
+**File:** `agent-bootstrap/src/main/java/org/jguard/bootstrap/Operation.java`
+
+```java
+public enum Operation {
+  FS_READ("fs.read", Category.FILESYSTEM),
+  FS_WRITE("fs.write", Category.FILESYSTEM),
+  NET_CONNECT("network.outbound", Category.SIMPLE),
+  NET_LISTEN("network.listen", Category.PORT),
+  THREAD_CREATE("threads.create", Category.SIMPLE);  // ← Add this line
+  ...
+}
+```
+
+#### Step 2: Add Entry Point in BootstrapEnforcer (~5 lines)
+
+**File:** `agent-bootstrap/src/main/java/org/jguard/bootstrap/BootstrapEnforcer.java`
+
+```java
+/**
+ * Called by ByteBuddy advice when a thread is being started.
+ */
+public static void onThreadCreate(Thread thread) {
+  dispatch(Operation.THREAD_CREATE, thread != null ? thread.getName() : "unnamed", 0);
+}
+```
+
+#### Step 3: Create Interceptor Advice (~20 lines)
+
+**File:** `agent/src/main/java/org/jguard/agent/ThreadInterceptor.java`
+
+```java
+public final class ThreadInterceptor {
+
+  private ThreadInterceptor() {}
+
+  public static class ThreadStartAdvice {
+
+    private ThreadStartAdvice() {}
+
+    @Advice.OnMethodEnter
+    public static void onEnter(@Advice.This Thread thread) {
+      BootstrapEnforcer.onThreadCreate(thread);
+    }
+  }
+}
+```
+
+#### Step 4: Wire Advice in JGuardAgent (~5 lines)
+
+**File:** `agent/src/main/java/org/jguard/agent/JGuardAgent.java`
+
+```java
+// Thread.start() instrumentation
+.type(named("java.lang.Thread"))
+.transform((builder, typeDescription, classLoader, module, protectionDomain) ->
+    builder.visit(
+        Advice.to(ThreadInterceptor.ThreadStartAdvice.class)
+            .on(named("start").and(takesNoArguments()))))
+```
+
+**That's it!** PolicyEnforcer's category-based dispatch handles `SIMPLE` capabilities automatically.
+
+### If Adding a New Category
+
+If your capability needs different matching logic, add a new category:
+
+#### Step 1: Add Category to Operation.Category enum
+
+```java
+public enum Category {
+  FILESYSTEM,
+  SIMPLE,
+  PORT,
+  TARGET_PATTERN,
+  MY_NEW_CATEGORY  // ← Add here
+}
+```
+
+#### Step 2: Update BootstrapEnforcer helpers
+
+Add cases to `formatArgs()` and `validateArgs()`:
+
+```java
+private static String formatArgs(Operation op, Object arg0, int arg1) {
+  return switch (op.category()) {
+    case FILESYSTEM -> String.valueOf(arg0);
+    case SIMPLE -> arg0 != null ? arg0 + ":" + arg1 : "n/a";
+    case PORT -> "port=" + arg1;
+    case TARGET_PATTERN -> arg0 != null ? String.valueOf(arg0) : "any";
+    case MY_NEW_CATEGORY -> /* your format */;
+  };
+}
+```
+
+#### Step 3: Update PolicyEnforcer category handlers
+
+Add cases to `formatDetails()`, `buildCacheKey()`, and `isAllowed()`:
+
+```java
+private boolean isAllowed(String callerPackage, Operation op, Object arg0, int arg1) {
+  String capability = op.capabilityName();
+  return switch (op.category()) {
+    case FILESYSTEM -> isAllowedFilesystem(callerPackage, (Path) arg0, capability);
+    case SIMPLE -> isAllowedSimple(callerPackage, capability);
+    case PORT -> isAllowedPort(callerPackage, arg1, capability);
+    case TARGET_PATTERN -> isAllowedTargetPattern(callerPackage, (String) arg0, capability);
+    case MY_NEW_CATEGORY -> isAllowedMyCategory(callerPackage, arg0, arg1, capability);
+  };
+}
+```
+
+Then implement `isAllowedMyCategory()` with your matching logic.
+
+This is a one-time cost (~30 lines) that enables all future capabilities in that category.
+
+## Testing
+
+### Unit Tests
+
+Add tests in `agent/src/test/java/org/jguard/agent/PolicyEnforcerTest.java`:
+
+```java
+@Nested
+@DisplayName("Thread create entitlements")
+class ThreadCreateTest {
+
+  @Test
+  @DisplayName("allows thread creation when entitled")
+  void allowsWhenEntitled() {
+    Entitlement entitlement = new Entitlement(
+        SubjectPattern.module(),
+        CapabilityGrant.of("threads.create"));
+    PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+    PolicyEnforcer enforcer = createEnforcer(policy);
+
+    assertThat(enforcer.check(caller("com.example.app"), Operation.THREAD_CREATE, "worker", 0))
+        .isNull();
+  }
+}
+```
+
+### Integration Tests
+
+Add a test case in `samples/sandbox-demo` that exercises the new capability with the agent.
+
+## Capability Design Guidelines
+
+1. **Choose the right category** - Use existing categories when possible
+2. **Minimal arguments** - Only include arguments needed for policy decisions
+3. **Consistent naming** - Follow existing patterns (`category.action`)
+4. **Clear semantics** - Document what the capability controls
+
+## Argument Conventions by Category
+
+| Category | arg0 | arg1 |
+|----------|------|------|
+| FILESYSTEM | `Path` | `0` (unused) |
+| SIMPLE | `String` description (for logging) | `0` (unused) |
+| PORT | `null` | `int` port |
+| TARGET_PATTERN | `String` target (class name, etc.) | `0` (unused) |
+
+## Common Pitfalls
+
+### Advice Classes
+
+- **Only reference bootstrap classes** - Advice is woven into JDK classes which can only see the bootstrap classloader
+- **No instance state** - Advice classes must be stateless with static methods
+- **Handle nulls** - Arguments may be null; check before calling BootstrapEnforcer
+
+### BootstrapEnforcer
+
+- **No external dependencies** - Bootstrap module must only use JDK classes
+- **Normalize in entry points** - Convert File→Path, InetSocketAddress→host+port before dispatch
+
+### PolicyEnforcer
+
+- **Category switches are exhaustive** - Missing cases cause compile errors
+- **Cache key uniqueness** - Include all relevant arguments in cache key
+
+## Building and Testing
+
+```bash
+# Build all modules
+./gradlew build
+
+# Run sandbox-demo without agent (no enforcement)
+cd samples/sandbox-demo && ../../gradlew run
+
+# Run sandbox-demo with agent (enforcement enabled)
+cd samples/sandbox-demo && ../../gradlew runWithAgent
+
+# Run with different modes
+../../gradlew runWithAgent -Pjguard.mode=audit
+../../gradlew runWithAgent -Pjguard.mode=permissive
+```
+
+## Questions?
+
+Open an issue at https://github.com/lucenia/jguard/issues

--- a/README.md
+++ b/README.md
@@ -126,11 +126,12 @@ Capabilities represent explicit permission to perform sensitive operations.
 
 Examples include:
 
-* `fs.read(root, glob)`
-* `fs.write(root, glob)`
-* `network.outbound`
-* `threads.create`
-* `native.load`
+* `fs.read(root, glob)` — read files matching glob pattern under root
+* `fs.write(root, glob)` — write files matching glob pattern under root
+* `network.outbound` — open outbound network connections
+* `network.listen` — bind server sockets to ports
+* `threads.create` — create new threads (planned)
+* `native.load` — load native libraries (planned)
 
 Capabilities are intentionally narrow and composable.
 
@@ -234,19 +235,21 @@ See [gradle-plugin/README.md](gradle-plugin/README.md) for full plugin documenta
 
 ## Status
 
-jGuard is under active development with production-hardened filesystem enforcement.
+jGuard is under active development with production-hardened enforcement.
 
 Completed:
 
 * Stable policy model with deterministic compilation
-* Comprehensive filesystem read enforcement
-* Clear failure semantics with configurable modes
+* Comprehensive filesystem enforcement (`fs.read`, `fs.write`)
+* Network enforcement (`network.outbound`, `network.listen`)
+* Clear failure semantics with configurable modes (STRICT, PERMISSIVE, AUDIT)
 * Strong JPMS integration with module verification
+* Single dispatch architecture for efficient capability checking
 
 In progress:
 
-* Network enforcement (`network.outbound`)
-* Additional capabilities
+* Thread management capabilities (`threads.create`)
+* Native library loading (`native.load`)
 
 ---
 

--- a/agent-bootstrap/src/main/java/org/jguard/bootstrap/BootstrapEnforcer.java
+++ b/agent-bootstrap/src/main/java/org/jguard/bootstrap/BootstrapEnforcer.java
@@ -11,8 +11,6 @@ import java.io.File;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.file.Path;
-import java.util.function.BiFunction;
-import java.util.function.Function;
 
 /**
  * Bootstrap enforcement bridge for jGuard.
@@ -38,50 +36,40 @@ import java.util.function.Function;
  *       v
  * BootstrapEnforcer.onFileRead()    <- bootstrap classloader
  *       |
- *       v
- * enforcementCallback               <- BiFunction set by agent
+ *       v (single dispatch)
+ * EnforcementCallback.check()       <- set by agent
  *       |
  *       v
- * PolicyEnforcer.checkFsRead()      <- agent classloader
+ * PolicyEnforcer                    <- agent classloader
  * }</pre>
  *
  * <h2>Thread Safety</h2>
  *
- * <p>All fields are volatile and methods are thread-safe. The callback is a BiFunction that returns
- * null for allowed, or a SecurityException for denied.
+ * <p>All fields are volatile and methods are thread-safe. The callback returns null for allowed, or
+ * a SecurityException for denied.
  */
 public final class BootstrapEnforcer {
 
   private static final AgentLogger LOG = AgentLogger.getLogger(BootstrapEnforcer.class);
 
-  /**
-   * Callback for filesystem read enforcement.
-   *
-   * <p>Parameters: (callerContext, path) Returns: null if allowed, SecurityException if denied
-   */
-  private static volatile BiFunction<CallerContext, Path, SecurityException> fsReadCallback;
+  /** Default skip prefixes for caller attribution. */
+  private static final String[] DEFAULT_SKIP_PREFIXES = {
+    // jGuard infrastructure - be specific to avoid matching application packages
+    "org.jguard.bootstrap.",
+    "org.jguard.agent.",
+    // ByteBuddy internals (agent uses relocated version too)
+    "net.bytebuddy.",
+    "org.jguard.internal.bytebuddy.",
+    // JDK internals
+    "java.",
+    "sun.",
+    "com.sun.",
+    "jdk.",
+    "jdk.internal."
+  };
 
-  /**
-   * Callback for filesystem write enforcement.
-   *
-   * <p>Parameters: (callerContext, path) Returns: null if allowed, SecurityException if denied
-   */
-  private static volatile BiFunction<CallerContext, Path, SecurityException> fsWriteCallback;
-
-  /**
-   * Callback for network outbound enforcement.
-   *
-   * <p>Parameters: (callerContext) Returns: null if allowed, SecurityException if denied
-   */
-  private static volatile Function<CallerContext, SecurityException> networkOutboundCallback;
-
-  /**
-   * Callback for network listen enforcement.
-   *
-   * <p>Parameters: (callerContext, port) Returns: null if allowed, SecurityException if denied
-   */
-  private static volatile BiFunction<CallerContext, Integer, SecurityException>
-      networkListenCallback;
+  /** Single enforcement callback for all operations. */
+  private static volatile EnforcementCallback callback;
 
   /** Current enforcement mode. */
   private static volatile EnforcementMode mode = EnforcementMode.STRICT;
@@ -92,65 +80,26 @@ public final class BootstrapEnforcer {
   /** Whether to log allowed operations. */
   private static volatile boolean logAllowed = false;
 
+  /** Skip prefixes for caller attribution. */
+  private static volatile String[] skipPrefixes = DEFAULT_SKIP_PREFIXES;
+
   /** Flag to prevent re-entrant calls during enforcement. */
   private static final ThreadLocal<Boolean> IN_ENFORCEMENT = ThreadLocal.withInitial(() -> false);
 
   private BootstrapEnforcer() {}
 
-  /**
-   * Configures the filesystem read enforcement callback.
-   *
-   * <p>Called by the agent during initialization.
-   *
-   * @param callback function that takes (CallerContext, Path) and returns null if allowed,
-   *     SecurityException if denied
-   */
-  public static void setFsReadCallback(
-      BiFunction<CallerContext, Path, SecurityException> callback) {
-    fsReadCallback = callback;
-    LOG.debug("Filesystem read enforcement callback configured");
-  }
+  // ========== CONFIGURATION ==========
 
   /**
-   * Configures the filesystem write enforcement callback.
+   * Configures the enforcement callback.
    *
    * <p>Called by the agent during initialization.
    *
-   * @param callback function that takes (CallerContext, Path) and returns null if allowed,
-   *     SecurityException if denied
+   * @param cb the callback that checks if operations are allowed
    */
-  public static void setFsWriteCallback(
-      BiFunction<CallerContext, Path, SecurityException> callback) {
-    fsWriteCallback = callback;
-    LOG.debug("Filesystem write enforcement callback configured");
-  }
-
-  /**
-   * Configures the network outbound enforcement callback.
-   *
-   * <p>Called by the agent during initialization.
-   *
-   * @param callback function that takes (CallerContext) and returns null if allowed,
-   *     SecurityException if denied
-   */
-  public static void setNetworkOutboundCallback(
-      Function<CallerContext, SecurityException> callback) {
-    networkOutboundCallback = callback;
-    LOG.debug("Network outbound enforcement callback configured");
-  }
-
-  /**
-   * Configures the network listen enforcement callback.
-   *
-   * <p>Called by the agent during initialization.
-   *
-   * @param callback function that takes (CallerContext, Integer port) and returns null if allowed,
-   *     SecurityException if denied
-   */
-  public static void setNetworkListenCallback(
-      BiFunction<CallerContext, Integer, SecurityException> callback) {
-    networkListenCallback = callback;
-    LOG.debug("Network listen enforcement callback configured");
+  public static void setCallback(EnforcementCallback cb) {
+    callback = cb;
+    LOG.debug("Enforcement callback configured");
   }
 
   /**
@@ -175,13 +124,26 @@ public final class BootstrapEnforcer {
   }
 
   /**
+   * Configures skip prefixes for caller attribution.
+   *
+   * <p>Classes matching these prefixes are skipped when walking the stack to find the caller.
+   *
+   * @param prefixes the prefixes to skip, or null to use defaults
+   */
+  public static void setSkipPrefixes(String[] prefixes) {
+    skipPrefixes = (prefixes == null) ? DEFAULT_SKIP_PREFIXES : prefixes.clone();
+  }
+
+  // ========== FILESYSTEM READ ENTRY POINTS ==========
+
+  /**
    * Called by ByteBuddy advice when a file read operation is intercepted (File variant).
    *
    * @param file the file being read
    */
   public static void onFileRead(File file) {
     if (file != null) {
-      onFileRead(file.toPath());
+      dispatch(Operation.FS_READ, file.toPath(), 0);
     }
   }
 
@@ -192,101 +154,20 @@ public final class BootstrapEnforcer {
    */
   public static void onFileRead(String pathString) {
     if (pathString != null) {
-      onFileRead(Path.of(pathString));
+      dispatch(Operation.FS_READ, Path.of(pathString), 0);
     }
   }
 
   /**
    * Called by ByteBuddy advice when a file read operation is intercepted.
    *
-   * <p>This method handles all the complexity of enforcement:
-   *
-   * <ul>
-   *   <li>Re-entrancy prevention (file operations during enforcement)
-   *   <li>JVM bootstrap detection (allow before agent is ready)
-   *   <li>Caller attribution with module verification
-   *   <li>Enforcement mode handling
-   *   <li>Error handling based on mode
-   * </ul>
-   *
    * @param path the path being read
    */
   public static void onFileRead(Path path) {
-    // Prevent re-entrancy - if we're already in enforcement, allow
-    if (Boolean.TRUE.equals(IN_ENFORCEMENT.get())) {
-      return;
-    }
-
-    BiFunction<CallerContext, Path, SecurityException> callback = fsReadCallback;
-    if (callback == null) {
-      // Agent not initialized - allow (JVM bootstrap)
-      return;
-    }
-
-    try {
-      IN_ENFORCEMENT.set(true);
-      enforceFileRead(path, callback);
-    } finally {
-      IN_ENFORCEMENT.set(false);
-    }
+    dispatch(Operation.FS_READ, path, 0);
   }
 
-  private static void enforceFileRead(
-      Path path, BiFunction<CallerContext, Path, SecurityException> callback) {
-    CallerInfo caller;
-    try {
-      caller = determineCallerInfo();
-    } catch (Exception e) {
-      handleEnforcementError("Failed to determine caller", path, e);
-      return;
-    }
-
-    String callerPackage = caller.packageName();
-    String callerModule = caller.moduleName();
-
-    // Handle unknown caller based on mode
-    if ("unknown".equals(callerPackage)) {
-      handleUnknownCaller("fs.read", path);
-      return;
-    }
-
-    try {
-      CallerContext context = caller.toContext();
-      SecurityException denial = callback.apply(context, path);
-
-      if (denial != null) {
-        // Access denied
-        if (logDenied) {
-          LOG.warn(
-              "DENIED fs.read: package={}, module={}, path={}", callerPackage, callerModule, path);
-        }
-        if (mode.blocksOnDenied()) {
-          throw denial;
-        }
-      } else {
-        // Access allowed
-        if (logAllowed) {
-          LOG.info(
-              "ALLOWED fs.read: package={}, module={}, path={}", callerPackage, callerModule, path);
-        }
-      }
-    } catch (SecurityException se) {
-      // Re-throw security exceptions
-      throw se;
-    } catch (Exception e) {
-      handleEnforcementError("Enforcement callback failed", path, e);
-    }
-  }
-
-  private static void handleUnknownCaller(String operation, Path path) {
-    // When the caller is "unknown", it typically means the call originated from JVM internals
-    // (class loading, module loading, etc.) without any application code in the stack.
-    // We must allow these operations for the JVM to function, even in STRICT mode.
-    //
-    // In STRICT mode, we log at DEBUG level to avoid noise from JVM bootstrap operations.
-    // Actual application-initiated operations will always have application code on the stack.
-    LOG.debug("Allowing {} from unknown caller (JVM internal): {}", operation, path);
-  }
+  // ========== FILESYSTEM WRITE ENTRY POINTS ==========
 
   /**
    * Called by ByteBuddy advice when a file write operation is intercepted (File variant).
@@ -295,7 +176,7 @@ public final class BootstrapEnforcer {
    */
   public static void onFileWrite(File file) {
     if (file != null) {
-      onFileWrite(file.toPath());
+      dispatch(Operation.FS_WRITE, file.toPath(), 0);
     }
   }
 
@@ -306,7 +187,7 @@ public final class BootstrapEnforcer {
    */
   public static void onFileWrite(String pathString) {
     if (pathString != null) {
-      onFileWrite(Path.of(pathString));
+      dispatch(Operation.FS_WRITE, Path.of(pathString), 0);
     }
   }
 
@@ -316,76 +197,10 @@ public final class BootstrapEnforcer {
    * @param path the path being written
    */
   public static void onFileWrite(Path path) {
-    // Prevent re-entrancy - if we're already in enforcement, allow
-    if (Boolean.TRUE.equals(IN_ENFORCEMENT.get())) {
-      return;
-    }
-
-    BiFunction<CallerContext, Path, SecurityException> callback = fsWriteCallback;
-    if (callback == null) {
-      // Agent not initialized - allow (JVM bootstrap)
-      return;
-    }
-
-    try {
-      IN_ENFORCEMENT.set(true);
-      enforceFileWrite(path, callback);
-    } finally {
-      IN_ENFORCEMENT.set(false);
-    }
+    dispatch(Operation.FS_WRITE, path, 0);
   }
 
-  private static void enforceFileWrite(
-      Path path, BiFunction<CallerContext, Path, SecurityException> callback) {
-    CallerInfo caller;
-    try {
-      caller = determineCallerInfo();
-    } catch (Exception e) {
-      handleEnforcementError("Failed to determine caller", path, e);
-      return;
-    }
-
-    String callerPackage = caller.packageName();
-    String callerModule = caller.moduleName();
-
-    // Handle unknown caller based on mode
-    if ("unknown".equals(callerPackage)) {
-      handleUnknownCaller("fs.write", path);
-      return;
-    }
-
-    try {
-      CallerContext context = caller.toContext();
-      SecurityException denial = callback.apply(context, path);
-
-      if (denial != null) {
-        // Access denied
-        if (logDenied) {
-          LOG.warn(
-              "DENIED fs.write: package={}, module={}, path={}", callerPackage, callerModule, path);
-        }
-        if (mode.blocksOnDenied()) {
-          throw denial;
-        }
-      } else {
-        // Access allowed
-        if (logAllowed) {
-          LOG.info(
-              "ALLOWED fs.write: package={}, module={}, path={}",
-              callerPackage,
-              callerModule,
-              path);
-        }
-      }
-    } catch (SecurityException se) {
-      // Re-throw security exceptions
-      throw se;
-    } catch (Exception e) {
-      handleEnforcementError("Enforcement callback failed", path, e);
-    }
-  }
-
-  // ========== NETWORK OUTBOUND ENFORCEMENT ==========
+  // ========== NETWORK OUTBOUND ENTRY POINTS ==========
 
   /**
    * Called by ByteBuddy advice when a network connect operation is intercepted (host/port variant).
@@ -394,7 +209,7 @@ public final class BootstrapEnforcer {
    * @param port the port being connected to
    */
   public static void onNetworkConnect(String host, int port) {
-    onNetworkConnectInternal(host, port);
+    dispatch(Operation.NET_CONNECT, host, port);
   }
 
   /**
@@ -405,9 +220,7 @@ public final class BootstrapEnforcer {
    */
   public static void onNetworkConnect(InetSocketAddress address) {
     if (address != null) {
-      String host = address.getHostString();
-      int port = address.getPort();
-      onNetworkConnectInternal(host, port);
+      dispatch(Operation.NET_CONNECT, address.getHostString(), address.getPort());
     }
   }
 
@@ -420,116 +233,19 @@ public final class BootstrapEnforcer {
    */
   public static void onNetworkConnect(InetAddress address, int port) {
     if (address != null) {
-      onNetworkConnectInternal(address.getHostAddress(), port);
+      dispatch(Operation.NET_CONNECT, address.getHostAddress(), port);
     }
   }
 
-  private static void onNetworkConnectInternal(String host, int port) {
-    // Prevent re-entrancy - if we're already in enforcement, allow
-    if (Boolean.TRUE.equals(IN_ENFORCEMENT.get())) {
-      return;
-    }
-
-    Function<CallerContext, SecurityException> callback = networkOutboundCallback;
-    if (callback == null) {
-      // Agent not initialized - allow (JVM bootstrap)
-      return;
-    }
-
-    try {
-      IN_ENFORCEMENT.set(true);
-      enforceNetworkOutbound(host, port, callback);
-    } finally {
-      IN_ENFORCEMENT.set(false);
-    }
-  }
-
-  private static void enforceNetworkOutbound(
-      String host, int port, Function<CallerContext, SecurityException> callback) {
-    CallerInfo caller;
-    try {
-      caller = determineCallerInfo();
-    } catch (Exception e) {
-      handleNetworkEnforcementError("Failed to determine caller", host, port, e);
-      return;
-    }
-
-    String callerPackage = caller.packageName();
-    String callerModule = caller.moduleName();
-
-    // Handle unknown caller based on mode
-    if ("unknown".equals(callerPackage)) {
-      handleUnknownNetworkCaller(host, port);
-      return;
-    }
-
-    try {
-      CallerContext context = caller.toContext();
-      SecurityException denial = callback.apply(context);
-
-      if (denial != null) {
-        // Access denied
-        if (logDenied) {
-          LOG.warn(
-              "DENIED network.outbound: package={}, module={}, target={}:{}",
-              callerPackage,
-              callerModule,
-              host,
-              port);
-        }
-        if (mode.blocksOnDenied()) {
-          throw denial;
-        }
-      } else {
-        // Access allowed
-        if (logAllowed) {
-          LOG.info(
-              "ALLOWED network.outbound: package={}, module={}, target={}:{}",
-              callerPackage,
-              callerModule,
-              host,
-              port);
-        }
-      }
-    } catch (SecurityException se) {
-      // Re-throw security exceptions
-      throw se;
-    } catch (Exception e) {
-      handleNetworkEnforcementError("Enforcement callback failed", host, port, e);
-    }
-  }
-
-  private static void handleUnknownNetworkCaller(String host, int port) {
-    // When the caller is "unknown", it typically means the call originated from JVM internals.
-    // We must allow these operations for the JVM to function, even in STRICT mode.
-    LOG.debug("Allowing network.outbound from unknown caller (JVM internal): {}:{}", host, port);
-  }
-
-  private static void handleNetworkEnforcementError(
-      String context, String host, int port, Exception e) {
-    String target = host + ":" + port;
-    if (mode.blocksOnError()) {
-      LOG.error("{}: {} - blocking network access to {}", context, e.getMessage(), target);
-      throw new SecurityException("jGuard: enforcement error - " + context + ": " + e.getMessage());
-    } else {
-      LOG.warn(
-          "{}: {} - allowing network access to {} (mode={})",
-          context,
-          e.getMessage(),
-          target,
-          mode);
-    }
-  }
-
-  // ========== NETWORK LISTEN ENFORCEMENT ==========
+  // ========== NETWORK LISTEN ENTRY POINTS ==========
 
   /**
    * Called by ByteBuddy advice when a server socket bind operation is intercepted (port variant).
    *
-   * @param port the port being bound to
+   * @param port the port being bound to (0 = bind-any-port)
    */
   public static void onNetworkListen(int port) {
-    onNetworkListenInternal(port);
+    dispatch(Operation.NET_LISTEN, null, port);
   }
 
   /**
@@ -539,65 +255,83 @@ public final class BootstrapEnforcer {
    * @param address the socket address being bound to
    */
   public static void onNetworkListen(InetSocketAddress address) {
-    if (address != null) {
-      onNetworkListenInternal(address.getPort());
-    } else {
-      // null address means bind to any available port
-      onNetworkListenInternal(0);
-    }
+    dispatch(Operation.NET_LISTEN, null, address != null ? address.getPort() : 0);
   }
 
-  private static void onNetworkListenInternal(int port) {
+  // ========== SINGLE DISPATCH ==========
+
+  /**
+   * Central dispatch point for all enforcement operations.
+   *
+   * <p>All entry points normalize their arguments and call this method. This ensures:
+   *
+   * <ul>
+   *   <li>Reentrancy prevention is handled in one place
+   *   <li>Caller attribution is handled in one place
+   *   <li>Error handling is handled in one place
+   *   <li>Logging is handled in one place
+   * </ul>
+   */
+  private static void dispatch(Operation op, Object arg0, int arg1) {
     // Prevent re-entrancy - if we're already in enforcement, allow
     if (Boolean.TRUE.equals(IN_ENFORCEMENT.get())) {
       return;
     }
 
-    BiFunction<CallerContext, Integer, SecurityException> callback = networkListenCallback;
-    if (callback == null) {
+    EnforcementCallback cb = callback;
+    if (cb == null) {
       // Agent not initialized - allow (JVM bootstrap)
       return;
     }
 
     try {
       IN_ENFORCEMENT.set(true);
-      enforceNetworkListen(port, callback);
+      enforce(op, arg0, arg1, cb);
     } finally {
       IN_ENFORCEMENT.set(false);
     }
   }
 
-  private static void enforceNetworkListen(
-      int port, BiFunction<CallerContext, Integer, SecurityException> callback) {
+  /**
+   * Performs the actual enforcement.
+   *
+   * <p>This method assumes reentrancy prevention is already handled.
+   */
+  private static void enforce(Operation op, Object arg0, int arg1, EnforcementCallback cb) {
+    // Determine caller
     CallerInfo caller;
     try {
       caller = determineCallerInfo();
     } catch (Exception e) {
-      handleNetworkListenEnforcementError("Failed to determine caller", port, e);
+      handleError(op, arg0, arg1, "Failed to determine caller", e);
       return;
     }
 
-    String callerPackage = caller.packageName();
-    String callerModule = caller.moduleName();
-
-    // Handle unknown caller based on mode
-    if ("unknown".equals(callerPackage)) {
-      handleUnknownNetworkListenCaller(port);
+    // Unknown caller = JVM internal operation, allow in all modes
+    if (!caller.known()) {
+      LOG.debug("Allowing {} from unknown caller (JVM internal)", op);
       return;
     }
 
+    // Validate argument types (catches advice wiring bugs)
+    if (!validateArgs(op, arg0, arg1)) {
+      handleError(op, arg0, arg1, "Invalid args for op", null);
+      return;
+    }
+
+    // Call the enforcement callback
     try {
-      CallerContext context = caller.toContext();
-      SecurityException denial = callback.apply(context, port);
+      SecurityException denial = cb.check(caller.toContext(), op, arg0, arg1);
 
       if (denial != null) {
         // Access denied
         if (logDenied) {
           LOG.warn(
-              "DENIED network.listen: package={}, module={}, port={}",
-              callerPackage,
-              callerModule,
-              port);
+              "DENIED {}: package={}, module={}, args={}",
+              op,
+              caller.packageName(),
+              caller.moduleName(),
+              formatArgs(op, arg0, arg1));
         }
         if (mode.blocksOnDenied()) {
           throw denial;
@@ -606,48 +340,69 @@ public final class BootstrapEnforcer {
         // Access allowed
         if (logAllowed) {
           LOG.info(
-              "ALLOWED network.listen: package={}, module={}, port={}",
-              callerPackage,
-              callerModule,
-              port);
+              "ALLOWED {}: package={}, module={}", op, caller.packageName(), caller.moduleName());
         }
       }
     } catch (SecurityException se) {
       // Re-throw security exceptions
       throw se;
     } catch (Exception e) {
-      handleNetworkListenEnforcementError("Enforcement callback failed", port, e);
+      handleError(op, arg0, arg1, "Enforcement callback failed", e);
     }
   }
 
-  private static void handleUnknownNetworkListenCaller(int port) {
-    // When the caller is "unknown", it typically means the call originated from JVM internals.
-    // We must allow these operations for the JVM to function, even in STRICT mode.
-    LOG.debug("Allowing network.listen from unknown caller (JVM internal): port={}", port);
+  // ========== HELPERS ==========
+
+  /**
+   * Formats operation arguments for logging.
+   *
+   * <p>Uses the operation's category to determine format. Adding new operations with existing
+   * categories requires no changes here.
+   */
+  private static String formatArgs(Operation op, Object arg0, int arg1) {
+    return switch (op.category()) {
+      case FILESYSTEM -> String.valueOf(arg0);
+      case SIMPLE -> arg0 != null ? arg0 + ":" + arg1 : "n/a";
+      case PORT -> "port=" + arg1;
+      case TARGET_PATTERN -> arg0 != null ? String.valueOf(arg0) : "any";
+    };
   }
 
-  private static void handleNetworkListenEnforcementError(String context, int port, Exception e) {
+  /**
+   * Validates argument types for an operation.
+   *
+   * <p>Uses the operation's category to determine expected types. Adding new operations with
+   * existing categories requires no changes here.
+   */
+  private static boolean validateArgs(Operation op, Object arg0, int arg1) {
+    return switch (op.category()) {
+      case FILESYSTEM -> arg0 instanceof Path;
+      case SIMPLE -> true; // No strict type requirement
+      case PORT -> true; // arg0 is null, arg1 is port
+      case TARGET_PATTERN -> arg0 == null || arg0 instanceof String;
+    };
+  }
+
+  /**
+   * Handles errors during enforcement.
+   *
+   * <p>Applies {@code mode.blocksOnError()} semantics: throws SecurityException in STRICT
+   * (fail-closed), logs and allows in PERMISSIVE/AUDIT.
+   */
+  private static void handleError(
+      Operation op, Object arg0, int arg1, String context, Exception e) {
+    String args = formatArgs(op, arg0, arg1);
     if (mode.blocksOnError()) {
-      LOG.error("{}: {} - blocking network listen on port {}", context, e.getMessage(), port);
-      throw new SecurityException("jGuard: enforcement error - " + context + ": " + e.getMessage());
+      String msg = e != null ? e.getMessage() : "unknown error";
+      LOG.error("{}: {} - blocking {} for {}", context, msg, op, args);
+      throw new SecurityException("jGuard: enforcement error - " + context + ": " + msg);
     } else {
-      LOG.warn(
-          "{}: {} - allowing network listen on port {} (mode={})",
-          context,
-          e.getMessage(),
-          port,
-          mode);
+      String msg = e != null ? e.getMessage() : "unknown error";
+      LOG.warn("{}: {} - allowing {} for {} (mode={})", context, msg, op, args, mode);
     }
   }
 
-  private static void handleEnforcementError(String context, Path path, Exception e) {
-    if (mode.blocksOnError()) {
-      LOG.error("{}: {} - blocking access to {}", context, e.getMessage(), path);
-      throw new SecurityException("jGuard: enforcement error - " + context + ": " + e.getMessage());
-    } else {
-      LOG.warn("{}: {} - allowing access to {} (mode={})", context, e.getMessage(), path, mode);
-    }
-  }
+  // ========== CALLER ATTRIBUTION ==========
 
   /**
    * Determines the calling code's package and module.
@@ -667,26 +422,19 @@ public final class BootstrapEnforcer {
                     .orElse(CallerInfo.UNKNOWN));
   }
 
+  /**
+   * Checks if a class is application code (not infrastructure).
+   *
+   * <p>Uses the configurable skipPrefixes to determine what to skip.
+   */
   private static boolean isApplicationCode(Class<?> clazz) {
     String name = clazz.getName();
 
-    // Skip jGuard infrastructure packages (but NOT sample apps or user code)
-    if (name.startsWith("org.jguard.agent.")
-        || name.startsWith("org.jguard.bootstrap.")
-        || name.startsWith("org.jguard.core.")
-        || name.startsWith("org.jguard.policy.")
-        || name.startsWith("org.jguard.internal.")) {
-      return false;
-    }
-
-    // Skip ByteBuddy (both original and relocated)
-    if (name.startsWith("net.bytebuddy.")) {
-      return false;
-    }
-
-    // Skip JDK infrastructure classes
-    if (name.startsWith("sun.") || name.startsWith("jdk.") || name.startsWith("java.")) {
-      return false;
+    // Skip infrastructure classes matching skip prefixes
+    for (String prefix : skipPrefixes) {
+      if (name.startsWith(prefix)) {
+        return false;
+      }
     }
 
     // Skip lambda and proxy classes - these are synthetic and we need to find the real caller
@@ -708,29 +456,24 @@ public final class BootstrapEnforcer {
     return true;
   }
 
-  /** Information about the caller making a capability request (internal). */
-  private record CallerInfo(String packageName, String moduleName) {
-    static final CallerInfo UNKNOWN = new CallerInfo("unknown", "unknown");
+  // ========== INTERNAL TYPES ==========
+
+  /**
+   * Information about the caller making a capability request (internal).
+   *
+   * <p>Uses a boolean sentinel {@code known()} instead of string comparison for unknown callers.
+   */
+  private record CallerInfo(String packageName, String moduleName, boolean known) {
+    static final CallerInfo UNKNOWN = new CallerInfo("", "", false);
 
     static CallerInfo from(Class<?> clazz) {
       Module module = clazz.getModule();
       String moduleName = module.isNamed() ? module.getName() : "unnamed";
-      return new CallerInfo(clazz.getPackageName(), moduleName);
+      return new CallerInfo(clazz.getPackageName(), moduleName, true);
     }
 
     CallerContext toContext() {
       return new CallerContext(packageName, moduleName);
     }
   }
-
-  /**
-   * Context information about the caller making a capability request.
-   *
-   * <p>This record is passed to the enforcement callback and contains the caller's package name and
-   * module name.
-   *
-   * @param packageName the caller's package name
-   * @param moduleName the caller's module name, or "unnamed" for unnamed modules
-   */
-  public record CallerContext(String packageName, String moduleName) {}
 }

--- a/agent-bootstrap/src/main/java/org/jguard/bootstrap/CallerContext.java
+++ b/agent-bootstrap/src/main/java/org/jguard/bootstrap/CallerContext.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The jGuard Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.jguard.bootstrap;
+
+/**
+ * Context information about the caller making a capability request.
+ *
+ * <p>This record is passed to the enforcement callback and contains the caller's package name and
+ * module name. It is the public API for caller information exposed to the agent layer.
+ *
+ * <h2>Thread Safety</h2>
+ *
+ * <p>This is an immutable record and is inherently thread-safe.
+ *
+ * @param packageName the caller's package name
+ * @param moduleName the caller's module name, or "unnamed" for unnamed modules
+ */
+public record CallerContext(String packageName, String moduleName) {}

--- a/agent-bootstrap/src/main/java/org/jguard/bootstrap/EnforcementCallback.java
+++ b/agent-bootstrap/src/main/java/org/jguard/bootstrap/EnforcementCallback.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The jGuard Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.jguard.bootstrap;
+
+/**
+ * Callback interface for policy enforcement.
+ *
+ * <p>This interface is the bridge between the bootstrap-loaded enforcement layer and the agent's
+ * policy evaluation. It is injected into the bootstrap classloader along with other bootstrap
+ * types, allowing the agent to implement it directly without reflection or proxy overhead.
+ *
+ * <h2>Thread Safety</h2>
+ *
+ * <p>Implementations must be thread-safe as they may be called concurrently from multiple threads.
+ *
+ * <h2>Error Handling</h2>
+ *
+ * <p>Implementations should return a {@link SecurityException} for denied operations rather than
+ * throwing, to allow the bootstrap layer to apply enforcement mode semantics.
+ */
+@FunctionalInterface
+public interface EnforcementCallback {
+
+  /**
+   * Checks if an operation should be allowed.
+   *
+   * @param caller the caller context (package and module information)
+   * @param op the operation being performed
+   * @param arg0 primary argument (type depends on operation - see {@link Operation} for contracts)
+   * @param arg1 secondary argument (type depends on operation - see {@link Operation} for
+   *     contracts)
+   * @return null if the operation is allowed, or a {@link SecurityException} if denied
+   */
+  SecurityException check(CallerContext caller, Operation op, Object arg0, int arg1);
+}

--- a/agent-bootstrap/src/main/java/org/jguard/bootstrap/Operation.java
+++ b/agent-bootstrap/src/main/java/org/jguard/bootstrap/Operation.java
@@ -1,0 +1,112 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The jGuard Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.jguard.bootstrap;
+
+/**
+ * Operations that require capability enforcement.
+ *
+ * <p>Each operation corresponds to a capability in the policy DSL. The {@link #capabilityName()}
+ * maps to the policy capability, and {@link #category()} determines the matching logic.
+ *
+ * <h2>Extending jGuard</h2>
+ *
+ * <p>To add a new capability:
+ *
+ * <ol>
+ *   <li>Add an enum entry here with capability name and category
+ *   <li>Add entry point in {@code BootstrapEnforcer.onXxx()}
+ *   <li>Add ByteBuddy advice calling the entry point
+ *   <li>Wire the advice in {@code JGuardAgent}
+ * </ol>
+ *
+ * <p>If using an existing category, no changes to PolicyEnforcer are needed.
+ */
+public enum Operation {
+
+  /**
+   * Filesystem read operation.
+   *
+   * <p>Arguments: {@code arg0} = Path, {@code arg1} = 0
+   */
+  FS_READ("fs.read", Category.FILESYSTEM),
+
+  /**
+   * Filesystem write operation.
+   *
+   * <p>Arguments: {@code arg0} = Path, {@code arg1} = 0
+   */
+  FS_WRITE("fs.write", Category.FILESYSTEM),
+
+  /**
+   * Network outbound connection.
+   *
+   * <p>Arguments: {@code arg0} = String host, {@code arg1} = port
+   */
+  NET_CONNECT("network.outbound", Category.SIMPLE),
+
+  /**
+   * Network listen (server socket bind).
+   *
+   * <p>Arguments: {@code arg0} = null, {@code arg1} = port (0 = ephemeral)
+   */
+  NET_LISTEN("network.listen", Category.PORT);
+
+  /**
+   * Categories determine matching logic in PolicyEnforcer.
+   *
+   * <p>Adding a new capability with an existing category requires no PolicyEnforcer changes.
+   */
+  public enum Category {
+    /**
+     * Filesystem operations with root + glob matching.
+     *
+     * <p>Policy args: {@code (root, glob)}
+     */
+    FILESYSTEM,
+
+    /**
+     * Simple capabilities with no argument matching.
+     *
+     * <p>If entitled, operation is allowed regardless of arguments.
+     */
+    SIMPLE,
+
+    /**
+     * Port-based capabilities with optional port restriction.
+     *
+     * <p>Policy args: none (any port) or {@code (port)} for specific port.
+     */
+    PORT,
+
+    /**
+     * Target pattern capabilities with optional pattern matching.
+     *
+     * <p>Policy args: none (any target) or {@code (pattern)} for specific targets. Use for
+     * reflection, native loading, process execution, etc.
+     */
+    TARGET_PATTERN
+  }
+
+  private final String capabilityName;
+  private final Category category;
+
+  Operation(String capabilityName, Category category) {
+    this.capabilityName = capabilityName;
+    this.category = category;
+  }
+
+  /** Returns the capability name used in policy files (e.g., "fs.read", "network.outbound"). */
+  public String capabilityName() {
+    return capabilityName;
+  }
+
+  /** Returns the category that determines matching logic. */
+  public Category category() {
+    return category;
+  }
+}

--- a/agent/README.md
+++ b/agent/README.md
@@ -10,7 +10,7 @@ java -javaagent:jguard-agent.jar=/path/to/policy.bin -jar myapp.jar
 
 ## How It Works
 
-The agent uses ByteBuddy to instrument `java.nio.file.Files` methods, intercepting file system operations and checking them against compiled policy files.
+The agent uses ByteBuddy to instrument JDK filesystem and network classes, intercepting operations and checking them against compiled policy files.
 
 ### Enforcement Flow
 
@@ -53,7 +53,7 @@ This separation is necessary because advice woven into JDK classes can only refe
 - **PERMISSIVE**: Block denied access, allow on errors. Useful for migration.
 - **AUDIT**: Log only, never block. Useful for policy development.
 
-## Instrumented Classes
+## Instrumented Classes (Read Operations)
 
 ### java.nio.file.Files
 
@@ -96,12 +96,87 @@ NIO channel API. The factory method is instrumented:
 
 - `FileChannel.open(Path, ...)`
 
+## Instrumented Classes (Write Operations)
+
+### java.nio.file.Files
+
+All write operations are instrumented:
+
+- `newOutputStream(Path)`
+- `newBufferedWriter(Path)`
+- `write(Path, byte[])`
+- `write(Path, Iterable)`
+- `writeString(Path, CharSequence)`
+- `copy(InputStream, Path)`
+- `copy(Path, OutputStream)`
+- `move(Path, Path)`
+- `createFile(Path)`
+- `createDirectory(Path)`
+- `createDirectories(Path)`
+- `delete(Path)`
+- `deleteIfExists(Path)`
+
+### java.io.FileOutputStream
+
+The legacy IO write API. Both constructors are instrumented:
+
+- `FileOutputStream(File)`
+- `FileOutputStream(String)`
+
+### java.io.FileWriter
+
+Character stream write API. Both constructors are instrumented:
+
+- `FileWriter(File)`
+- `FileWriter(String)`
+
+## Instrumented Classes (Network Outbound)
+
+### java.net.Socket
+
+Client socket connections are instrumented:
+
+- `Socket(String, int)`
+- `Socket(InetAddress, int)`
+- `Socket.connect(SocketAddress)`
+
+### java.nio.channels.SocketChannel
+
+NIO socket connections are instrumented:
+
+- `SocketChannel.connect(SocketAddress)`
+
+## Instrumented Classes (Network Listen)
+
+### java.net.ServerSocket
+
+Server socket binding is instrumented:
+
+- `ServerSocket(int)`
+- `ServerSocket(int, int)`
+- `ServerSocket.bind(SocketAddress)`
+
+### java.nio.channels.ServerSocketChannel
+
+NIO server socket binding is instrumented:
+
+- `ServerSocketChannel.bind(SocketAddress)`
+
 ## Limitations
 
-### Current Scope (M3.1)
+### Current Scope
 
-- Only `fs.read` capability is enforced
-- Write operations are not yet instrumented
+The following capabilities are fully enforced:
+
+- `fs.read` — filesystem read operations
+- `fs.write` — filesystem write operations
+- `network.outbound` — outbound socket connections
+- `network.listen` — server socket binding
+
+### Not Yet Implemented
+
+- `threads.create` — thread creation
+- `native.load` — native library loading
 
 ### JVM Bootstrap Operations
 

--- a/agent/src/main/java/org/jguard/agent/JGuardAgent.java
+++ b/agent/src/main/java/org/jguard/agent/JGuardAgent.java
@@ -204,130 +204,75 @@ public final class JGuardAgent {
   }
 
   /**
-   * Configures the bootstrap enforcer with the callback and settings.
+   * Configures the bootstrap enforcer with the single callback and settings.
    *
-   * <p>We must use reflection because:
+   * <p>We use Proxy to bridge the classloader gap: bootstrap and app classloaders have separate
+   * copies of CallerContext/Operation/EnforcementCallback. A direct lambda would fail with
+   * LinkageError due to type identity mismatch.
    *
-   * <ul>
-   *   <li>BootstrapEnforcer was loaded by the bootstrap classloader
-   *   <li>The class visible to us is from the agent classloader
-   *   <li>These are different Class objects with separate static fields
-   * </ul>
+   * <p>Future: fix packaging so agent uses compileOnly for bootstrap types, enabling direct lambdas
+   * with single type identity at runtime.
    */
   private static void configureBootstrapEnforcer() {
     try {
-      // Load BootstrapEnforcer from bootstrap classloader
+      // Bootstrap-loaded types
       Class<?> enforcerClass = Class.forName("org.jguard.bootstrap.BootstrapEnforcer", true, null);
-
-      // Load EnforcementMode from bootstrap classloader
       Class<?> modeClass = Class.forName("org.jguard.bootstrap.EnforcementMode", true, null);
+      Class<?> callbackClass =
+          Class.forName("org.jguard.bootstrap.EnforcementCallback", true, null);
+      Class<?> callerContextClass = Class.forName("org.jguard.bootstrap.CallerContext", true, null);
 
-      // Get CallerContext class from bootstrap classloader
-      Class<?> callerContextClass =
-          Class.forName("org.jguard.bootstrap.BootstrapEnforcer$CallerContext", true, null);
+      // Cache reflection for bootstrap CallerContext accessors (hot path uses these)
+      java.lang.reflect.Method getPackage = callerContextClass.getMethod("packageName");
+      java.lang.reflect.Method getModule = callerContextClass.getMethod("moduleName");
 
-      // Set the enforcement callback
-      java.lang.reflect.Method setCallback =
-          enforcerClass.getMethod("setFsReadCallback", java.util.function.BiFunction.class);
+      // Create proxy implementing bootstrap EnforcementCallback
+      Object callbackProxy =
+          java.lang.reflect.Proxy.newProxyInstance(
+              null, // bootstrap loader
+              new Class<?>[] {callbackClass},
+              (proxy, method, args) -> {
+                // Handle Object methods
+                String name = method.getName();
+                if (name.equals("toString")) return "JGuardEnforcementCallbackProxy";
+                if (name.equals("hashCode")) return System.identityHashCode(proxy);
+                if (name.equals("equals")) return proxy == args[0];
 
-      // The callback receives CallerContext from bootstrap classloader, so we need to
-      // extract its fields via reflection and create our own CallerContext
-      java.util.function.BiFunction<Object, Path, SecurityException> readCallback =
-          (bootstrapContext, path) -> {
-            try {
-              // Extract package and module from the bootstrap CallerContext
-              java.lang.reflect.Method getPackage = callerContextClass.getMethod("packageName");
-              java.lang.reflect.Method getModule = callerContextClass.getMethod("moduleName");
-              String packageName = (String) getPackage.invoke(bootstrapContext);
-              String moduleName = (String) getModule.invoke(bootstrapContext);
+                if (!name.equals("check")) {
+                  return null;
+                }
 
-              // Create our CallerContext (from agent classloader) with the same values
-              org.jguard.bootstrap.BootstrapEnforcer.CallerContext context =
-                  new org.jguard.bootstrap.BootstrapEnforcer.CallerContext(packageName, moduleName);
+                // Signature: check(CallerContext caller, Operation op, Object arg0, int arg1)
+                Object bootstrapCaller = args[0];
+                Object bootstrapOp = args[1];
+                Object arg0 = args[2];
+                int arg1 = (Integer) args[3];
 
-              return enforcer.checkFsReadReturningException(context, path);
-            } catch (Exception e) {
-              throw new RuntimeException("Failed to extract caller context", e);
-            }
-          };
+                // Convert bootstrap CallerContext -> agent-visible CallerContext
+                String pkg = (String) getPackage.invoke(bootstrapCaller);
+                String mod = (String) getModule.invoke(bootstrapCaller);
+                org.jguard.bootstrap.CallerContext agentCaller =
+                    new org.jguard.bootstrap.CallerContext(pkg, mod);
 
-      setCallback.invoke(null, readCallback);
+                // Convert bootstrap Operation -> agent Operation by name
+                String opName = ((Enum<?>) bootstrapOp).name();
+                org.jguard.bootstrap.Operation agentOp =
+                    org.jguard.bootstrap.Operation.valueOf(opName);
 
-      // Set up fs.write callback
-      java.lang.reflect.Method setWriteCallback =
-          enforcerClass.getMethod("setFsWriteCallback", java.util.function.BiFunction.class);
+                // Single dispatch to PolicyEnforcer.check()
+                return enforcer.check(agentCaller, agentOp, arg0, arg1);
+              });
 
-      java.util.function.BiFunction<Object, Path, SecurityException> writeCallback =
-          (bootstrapContext, path) -> {
-            try {
-              java.lang.reflect.Method getPackage = callerContextClass.getMethod("packageName");
-              java.lang.reflect.Method getModule = callerContextClass.getMethod("moduleName");
-              String packageName = (String) getPackage.invoke(bootstrapContext);
-              String moduleName = (String) getModule.invoke(bootstrapContext);
+      // Register callback reflectively on bootstrap BootstrapEnforcer
+      java.lang.reflect.Method setCallback = enforcerClass.getMethod("setCallback", callbackClass);
+      setCallback.invoke(null, callbackProxy);
 
-              org.jguard.bootstrap.BootstrapEnforcer.CallerContext context =
-                  new org.jguard.bootstrap.BootstrapEnforcer.CallerContext(packageName, moduleName);
-
-              return enforcer.checkFsWriteReturningException(context, path);
-            } catch (Exception e) {
-              throw new RuntimeException("Failed to extract caller context", e);
-            }
-          };
-
-      setWriteCallback.invoke(null, writeCallback);
-
-      // Set up network.outbound callback
-      java.lang.reflect.Method setNetworkCallback =
-          enforcerClass.getMethod("setNetworkOutboundCallback", java.util.function.Function.class);
-
-      java.util.function.Function<Object, SecurityException> networkCallback =
-          (bootstrapContext) -> {
-            try {
-              java.lang.reflect.Method getPackage = callerContextClass.getMethod("packageName");
-              java.lang.reflect.Method getModule = callerContextClass.getMethod("moduleName");
-              String packageName = (String) getPackage.invoke(bootstrapContext);
-              String moduleName = (String) getModule.invoke(bootstrapContext);
-
-              org.jguard.bootstrap.BootstrapEnforcer.CallerContext context =
-                  new org.jguard.bootstrap.BootstrapEnforcer.CallerContext(packageName, moduleName);
-
-              return enforcer.checkNetworkOutboundReturningException(context);
-            } catch (Exception e) {
-              throw new RuntimeException("Failed to extract caller context", e);
-            }
-          };
-
-      setNetworkCallback.invoke(null, networkCallback);
-
-      // Set up network.listen callback
-      java.lang.reflect.Method setNetworkListenCallback =
-          enforcerClass.getMethod("setNetworkListenCallback", java.util.function.BiFunction.class);
-
-      java.util.function.BiFunction<Object, Integer, SecurityException> networkListenCallback =
-          (bootstrapContext, port) -> {
-            try {
-              java.lang.reflect.Method getPackage = callerContextClass.getMethod("packageName");
-              java.lang.reflect.Method getModule = callerContextClass.getMethod("moduleName");
-              String packageName = (String) getPackage.invoke(bootstrapContext);
-              String moduleName = (String) getModule.invoke(bootstrapContext);
-
-              org.jguard.bootstrap.BootstrapEnforcer.CallerContext context =
-                  new org.jguard.bootstrap.BootstrapEnforcer.CallerContext(packageName, moduleName);
-
-              return enforcer.checkNetworkListenReturningException(context, port);
-            } catch (Exception e) {
-              throw new RuntimeException("Failed to extract caller context", e);
-            }
-          };
-
-      setNetworkListenCallback.invoke(null, networkListenCallback);
-
-      // Set enforcement mode
+      // Set mode (bootstrap enum identity)
       java.lang.reflect.Method setMode = enforcerClass.getMethod("setMode", modeClass);
       Object bootstrapMode = getEnumConstant(modeClass, config.mode().name());
       setMode.invoke(null, bootstrapMode);
 
-      // Set logging configuration
+      // Logging flags
       java.lang.reflect.Method setLogging =
           enforcerClass.getMethod("setLogging", boolean.class, boolean.class);
       setLogging.invoke(null, config.logDenied(), config.logAllowed());

--- a/agent/src/main/java/org/jguard/agent/PolicyEnforcer.java
+++ b/agent/src/main/java/org/jguard/agent/PolicyEnforcer.java
@@ -15,7 +15,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.jguard.bootstrap.AgentConfig;
 import org.jguard.bootstrap.AgentLogger;
-import org.jguard.bootstrap.BootstrapEnforcer.CallerContext;
+import org.jguard.bootstrap.CallerContext;
+import org.jguard.bootstrap.Operation;
 import org.jguard.policy.model.CapabilityArgument;
 import org.jguard.policy.model.Entitlement;
 import org.jguard.policy.model.PolicyDescriptor;
@@ -44,187 +45,105 @@ public final class PolicyEnforcer {
     this.policy = policy;
     this.moduleName = policy.moduleName();
     this.config = config;
-    indexFsEntitlements();
+    indexEntitlements();
     LOG.info("PolicyEnforcer initialized for module: {}", moduleName);
   }
 
+  // ========== SINGLE DISPATCH ENTRY POINT ==========
+
   /**
-   * Checks if the caller is entitled to read the specified path.
+   * Checks if the caller is entitled to perform the specified operation.
    *
-   * <p>This method verifies both the package and module of the caller against the policy. A caller
-   * is only allowed if:
+   * <p>This is the single entry point for all capability checks. It handles:
    *
    * <ul>
-   *   <li>The caller's module matches the policy's expected module, OR
-   *   <li>The caller is in an unnamed module (classpath) and the policy allows unnamed modules
-   *   <li>AND the caller's package matches an entitlement for the requested path
+   *   <li>Module identity verification
+   *   <li>Decision caching for performance
+   *   <li>Dispatch to operation-specific entitlement checking
    * </ul>
    *
    * @param context the caller context containing package and module information
-   * @param path the path being accessed
+   * @param op the operation being performed
+   * @param arg0 primary argument (Path for fs ops, String host for net connect, null for listen)
+   * @param arg1 secondary argument (0 for fs ops, port for network ops)
    * @return null if allowed, SecurityException if denied
    */
-  public SecurityException checkFsReadReturningException(CallerContext context, Path path) {
+  public SecurityException check(CallerContext context, Operation op, Object arg0, int arg1) {
     String callerPackage = context.packageName();
     String callerModule = context.moduleName();
 
     // First, verify module identity
     if (!isValidModule(callerModule)) {
       LOG.debug("Module mismatch: caller module={}, expected module={}", callerModule, moduleName);
-      return deniedModuleMismatch(callerPackage, callerModule, path.toString());
+      return deniedModuleMismatch(callerPackage, callerModule, formatDetails(op, arg0, arg1));
     }
 
-    String cacheKey = callerPackage + ":" + callerModule + ":fs.read:" + path.toAbsolutePath();
+    // Build cache key
+    String cacheKey = buildCacheKey(callerPackage, callerModule, op, arg0, arg1);
     Boolean cached = decisionCache.get(cacheKey);
     if (cached != null) {
-      return cached ? null : denied(callerPackage, "fs.read", path.toString());
+      return cached
+          ? null
+          : denied(callerPackage, op.capabilityName(), formatDetails(op, arg0, arg1));
     }
 
-    boolean allowed = isAllowedFsRead(callerPackage, path);
+    // Check entitlements
+    boolean allowed = isAllowed(callerPackage, op, arg0, arg1);
     decisionCache.put(cacheKey, allowed);
 
-    return allowed ? null : denied(callerPackage, "fs.read", path.toString());
+    return allowed
+        ? null
+        : denied(callerPackage, op.capabilityName(), formatDetails(op, arg0, arg1));
+  }
+
+  // ========== CATEGORY-BASED DISPATCH ==========
+
+  /**
+   * Formats operation details for error messages.
+   *
+   * <p>Uses operation category - adding new operations with existing categories requires no
+   * changes.
+   */
+  private static String formatDetails(Operation op, Object arg0, int arg1) {
+    return switch (op.category()) {
+      case FILESYSTEM -> arg0 != null ? arg0.toString() : "unknown path";
+      case SIMPLE -> op.capabilityName();
+      case PORT -> "port " + arg1;
+      case TARGET_PATTERN -> arg0 != null ? arg0.toString() : "any target";
+    };
   }
 
   /**
-   * Checks if the caller is entitled to read the specified path. Throws if denied.
+   * Builds a cache key for the given operation.
    *
-   * @param context the caller context containing package and module information
-   * @param path the path being accessed
-   * @throws SecurityException if access is denied
+   * <p>Uses operation category - adding new operations with existing categories requires no
+   * changes.
    */
-  public void checkFsRead(CallerContext context, Path path) {
-    SecurityException denial = checkFsReadReturningException(context, path);
-    if (denial != null) {
-      throw denial;
-    }
+  private static String buildCacheKey(
+      String callerPackage, String callerModule, Operation op, Object arg0, int arg1) {
+    String base = callerPackage + ":" + callerModule + ":" + op.capabilityName();
+    return switch (op.category()) {
+      case FILESYSTEM -> base + ":" + ((Path) arg0).toAbsolutePath();
+      case SIMPLE -> base;
+      case PORT -> base + ":" + arg1;
+      case TARGET_PATTERN -> base + ":" + (arg0 != null ? arg0 : "any");
+    };
   }
 
   /**
-   * Checks if the caller is entitled to write to the specified path.
+   * Dispatches to category-specific entitlement checking.
    *
-   * @param context the caller context containing package and module information
-   * @param path the path being written
-   * @return null if allowed, SecurityException if denied
+   * <p>Uses operation category - adding new operations with existing categories requires no
+   * changes.
    */
-  public SecurityException checkFsWriteReturningException(CallerContext context, Path path) {
-    String callerPackage = context.packageName();
-    String callerModule = context.moduleName();
-
-    // First, verify module identity
-    if (!isValidModule(callerModule)) {
-      LOG.debug("Module mismatch: caller module={}, expected module={}", callerModule, moduleName);
-      return deniedModuleMismatch(callerPackage, callerModule, path.toString());
-    }
-
-    String cacheKey = callerPackage + ":" + callerModule + ":fs.write:" + path.toAbsolutePath();
-    Boolean cached = decisionCache.get(cacheKey);
-    if (cached != null) {
-      return cached ? null : denied(callerPackage, "fs.write", path.toString());
-    }
-
-    boolean allowed = isAllowedFsWrite(callerPackage, path);
-    decisionCache.put(cacheKey, allowed);
-
-    return allowed ? null : denied(callerPackage, "fs.write", path.toString());
-  }
-
-  /**
-   * Checks if the caller is entitled to write to the specified path. Throws if denied.
-   *
-   * @param context the caller context containing package and module information
-   * @param path the path being written
-   * @throws SecurityException if access is denied
-   */
-  public void checkFsWrite(CallerContext context, Path path) {
-    SecurityException denial = checkFsWriteReturningException(context, path);
-    if (denial != null) {
-      throw denial;
-    }
-  }
-
-  /**
-   * Checks if the caller is entitled to make outbound network connections.
-   *
-   * @param context the caller context containing package and module information
-   * @return null if allowed, SecurityException if denied
-   */
-  public SecurityException checkNetworkOutboundReturningException(CallerContext context) {
-    String callerPackage = context.packageName();
-    String callerModule = context.moduleName();
-
-    // First, verify module identity
-    if (!isValidModule(callerModule)) {
-      LOG.debug("Module mismatch: caller module={}, expected module={}", callerModule, moduleName);
-      return deniedModuleMismatch(callerPackage, callerModule, "network.outbound");
-    }
-
-    String cacheKey = callerPackage + ":" + callerModule + ":network.outbound";
-    Boolean cached = decisionCache.get(cacheKey);
-    if (cached != null) {
-      return cached ? null : denied(callerPackage, "network.outbound", "outbound connection");
-    }
-
-    boolean allowed = isAllowedNetworkOutbound(callerPackage);
-    decisionCache.put(cacheKey, allowed);
-
-    return allowed ? null : denied(callerPackage, "network.outbound", "outbound connection");
-  }
-
-  /**
-   * Checks if the caller is entitled to make outbound network connections. Throws if denied.
-   *
-   * @param context the caller context containing package and module information
-   * @throws SecurityException if access is denied
-   */
-  public void checkNetworkOutbound(CallerContext context) {
-    SecurityException denial = checkNetworkOutboundReturningException(context);
-    if (denial != null) {
-      throw denial;
-    }
-  }
-
-  /**
-   * Checks if the caller is entitled to listen on a server socket.
-   *
-   * @param context the caller context containing package and module information
-   * @param port the port being bound to
-   * @return null if allowed, SecurityException if denied
-   */
-  public SecurityException checkNetworkListenReturningException(CallerContext context, int port) {
-    String callerPackage = context.packageName();
-    String callerModule = context.moduleName();
-
-    // First, verify module identity
-    if (!isValidModule(callerModule)) {
-      LOG.debug("Module mismatch: caller module={}, expected module={}", callerModule, moduleName);
-      return deniedModuleMismatch(callerPackage, callerModule, "network.listen");
-    }
-
-    String cacheKey = callerPackage + ":" + callerModule + ":network.listen:" + port;
-    Boolean cached = decisionCache.get(cacheKey);
-    if (cached != null) {
-      return cached ? null : denied(callerPackage, "network.listen", "port " + port);
-    }
-
-    boolean allowed = isAllowedNetworkListen(callerPackage, port);
-    decisionCache.put(cacheKey, allowed);
-
-    return allowed ? null : denied(callerPackage, "network.listen", "port " + port);
-  }
-
-  /**
-   * Checks if the caller is entitled to listen on a server socket. Throws if denied.
-   *
-   * @param context the caller context containing package and module information
-   * @param port the port being bound to
-   * @throws SecurityException if access is denied
-   */
-  public void checkNetworkListen(CallerContext context, int port) {
-    SecurityException denial = checkNetworkListenReturningException(context, port);
-    if (denial != null) {
-      throw denial;
-    }
+  private boolean isAllowed(String callerPackage, Operation op, Object arg0, int arg1) {
+    String capability = op.capabilityName();
+    return switch (op.category()) {
+      case FILESYSTEM -> isAllowedFilesystem(callerPackage, (Path) arg0, capability);
+      case SIMPLE -> isAllowedSimple(callerPackage, capability);
+      case PORT -> isAllowedPort(callerPackage, arg1, capability);
+      case TARGET_PATTERN -> isAllowedTargetPattern(callerPackage, (String) arg0, capability);
+    };
   }
 
   /**
@@ -256,37 +175,39 @@ public final class PolicyEnforcer {
     return false;
   }
 
-  private boolean isAllowedFsRead(String callerPackage, Path path) {
-    return isAllowedFsOperation(callerPackage, path, "fs.read");
-  }
+  // ========== CATEGORY HANDLERS ==========
 
-  private boolean isAllowedFsWrite(String callerPackage, Path path) {
-    return isAllowedFsOperation(callerPackage, path, "fs.write");
-  }
-
-  private boolean isAllowedNetworkOutbound(String callerPackage) {
-    // Check all entitlements that apply to this caller
+  /**
+   * Handles SIMPLE category - no argument matching, just subject check.
+   *
+   * <p>Used for: network.outbound, threads.create, etc.
+   */
+  private boolean isAllowedSimple(String callerPackage, String capability) {
     for (Entitlement entitlement : policy.entitlements()) {
-      if (!entitlement.capability().name().equals("network.outbound")) {
+      if (!entitlement.capability().name().equals(capability)) {
         continue;
       }
       if (!subjectMatches(entitlement.subject(), callerPackage)) {
         continue;
       }
 
-      // network.outbound takes no arguments - if the subject matches, it's allowed
-      LOG.debug("network.outbound allowed: package={}, entitlement={}", callerPackage, entitlement);
+      // Simple capabilities take no arguments - if the subject matches, it's allowed
+      LOG.debug("{} allowed: package={}, entitlement={}", capability, callerPackage, entitlement);
       return true;
     }
 
-    LOG.debug("network.outbound denied: package={}", callerPackage);
+    LOG.debug("{} denied: package={}", capability, callerPackage);
     return false;
   }
 
-  private boolean isAllowedNetworkListen(String callerPackage, int port) {
-    // Check all entitlements that apply to this caller
+  /**
+   * Handles PORT category - optional port restriction.
+   *
+   * <p>Used for: network.listen
+   */
+  private boolean isAllowedPort(String callerPackage, int port, String capability) {
     for (Entitlement entitlement : policy.entitlements()) {
-      if (!entitlement.capability().name().equals("network.listen")) {
+      if (!entitlement.capability().name().equals(capability)) {
         continue;
       }
       if (!subjectMatches(entitlement.subject(), callerPackage)) {
@@ -295,20 +216,22 @@ public final class PolicyEnforcer {
 
       List<CapabilityArgument> args = entitlement.capability().arguments();
       if (args.isEmpty()) {
-        // network.listen with no arguments - allows any port
+        // No arguments - allows any port
         LOG.debug(
-            "network.listen allowed (any port): package={}, port={}, entitlement={}",
+            "{} allowed (any port): package={}, port={}, entitlement={}",
+            capability,
             callerPackage,
             port,
             entitlement);
         return true;
       } else if (args.size() == 1) {
-        // network.listen(port) - check specific port
+        // Specific port restriction
         long allowedPort = ((CapabilityArgument.IntegerArg) args.get(0)).value();
         if (port == allowedPort || port == 0) {
-          // Port 0 means "any available port" - we allow it if they have any listen entitlement
+          // Port 0 means "any available port" - allow if they have any entitlement
           LOG.debug(
-              "network.listen allowed (port match): package={}, port={}, entitlement={}",
+              "{} allowed (port match): package={}, port={}, entitlement={}",
+              capability,
               callerPackage,
               port,
               entitlement);
@@ -317,11 +240,92 @@ public final class PolicyEnforcer {
       }
     }
 
-    LOG.debug("network.listen denied: package={}, port={}", callerPackage, port);
+    LOG.debug("{} denied: package={}, port={}", capability, callerPackage, port);
     return false;
   }
 
-  private boolean isAllowedFsOperation(String callerPackage, Path path, String capability) {
+  /**
+   * Handles TARGET_PATTERN category - optional pattern restriction.
+   *
+   * <p>Used for: reflect.invoke, native.load, process.exec, etc.
+   */
+  private boolean isAllowedTargetPattern(String callerPackage, String target, String capability) {
+    for (Entitlement entitlement : policy.entitlements()) {
+      if (!entitlement.capability().name().equals(capability)) {
+        continue;
+      }
+      if (!subjectMatches(entitlement.subject(), callerPackage)) {
+        continue;
+      }
+
+      List<CapabilityArgument> args = entitlement.capability().arguments();
+      if (args.isEmpty()) {
+        // No arguments - allows any target
+        LOG.debug(
+            "{} allowed (any target): package={}, target={}, entitlement={}",
+            capability,
+            callerPackage,
+            target,
+            entitlement);
+        return true;
+      } else if (args.size() == 1) {
+        // Pattern restriction - match target against pattern
+        String pattern = ((CapabilityArgument.StringArg) args.get(0)).value();
+        if (targetMatchesPattern(target, pattern)) {
+          LOG.debug(
+              "{} allowed (pattern match): package={}, target={}, pattern={}, entitlement={}",
+              capability,
+              callerPackage,
+              target,
+              pattern,
+              entitlement);
+          return true;
+        }
+      }
+    }
+
+    LOG.debug("{} denied: package={}, target={}", capability, callerPackage, target);
+    return false;
+  }
+
+  /**
+   * Matches a target (class name, library path, etc.) against a pattern.
+   *
+   * <p>Pattern syntax:
+   *
+   * <ul>
+   *   <li>{@code com.example.Foo} - exact match
+   *   <li>{@code com.example.*} - matches direct children (com.example.Foo, not
+   *       com.example.sub.Bar)
+   *   <li>{@code com.example.**} - matches all descendants
+   * </ul>
+   */
+  private boolean targetMatchesPattern(String target, String pattern) {
+    if (target == null) {
+      return false;
+    }
+    if (pattern.endsWith(".**")) {
+      String prefix = pattern.substring(0, pattern.length() - 3);
+      return target.equals(prefix) || target.startsWith(prefix + ".");
+    } else if (pattern.endsWith(".*")) {
+      String prefix = pattern.substring(0, pattern.length() - 2);
+      if (!target.startsWith(prefix + ".")) {
+        return false;
+      }
+      // Check there's exactly one more segment (no more dots after prefix)
+      String remainder = target.substring(prefix.length() + 1);
+      return !remainder.contains(".");
+    } else {
+      return target.equals(pattern);
+    }
+  }
+
+  /**
+   * Handles FILESYSTEM category - root + glob matching.
+   *
+   * <p>Used for: fs.read, fs.write
+   */
+  private boolean isAllowedFilesystem(String callerPackage, Path path, String capability) {
     Path absPath = path.toAbsolutePath().normalize();
 
     // Check all entitlements that apply to this caller
@@ -405,15 +409,9 @@ public final class PolicyEnforcer {
     return matcher.matches(relativePath);
   }
 
-  private void indexFsEntitlements() {
+  private void indexEntitlements() {
     for (Entitlement entitlement : policy.entitlements()) {
-      String capName = entitlement.capability().name();
-      if (capName.equals("fs.read")
-          || capName.equals("fs.write")
-          || capName.equals("network.outbound")
-          || capName.equals("network.listen")) {
-        LOG.debug("Indexed {} entitlement: {}", capName, entitlement);
-      }
+      LOG.debug("Indexed entitlement: {}", entitlement);
     }
   }
 

--- a/agent/src/test/java/org/jguard/agent/PolicyEnforcerTest.java
+++ b/agent/src/test/java/org/jguard/agent/PolicyEnforcerTest.java
@@ -13,8 +13,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.nio.file.Path;
 import java.util.List;
 import org.jguard.bootstrap.AgentConfig;
-import org.jguard.bootstrap.BootstrapEnforcer.CallerContext;
+import org.jguard.bootstrap.CallerContext;
 import org.jguard.bootstrap.EnforcementMode;
+import org.jguard.bootstrap.Operation;
 import org.jguard.policy.model.CapabilityArgument;
 import org.jguard.policy.model.CapabilityGrant;
 import org.jguard.policy.model.Entitlement;
@@ -58,9 +59,9 @@ class PolicyEnforcerTest {
       PolicyEnforcer enforcer = createEnforcer(policy);
 
       // Any package in the module should be allowed
-      assertThatCode(() -> enforcer.checkFsRead(caller("com.example.app"), dataFile))
+      assertThatCode(() -> checkFsRead(enforcer, caller("com.example.app"), dataFile))
           .doesNotThrowAnyException();
-      assertThatCode(() -> enforcer.checkFsRead(caller("com.example.app.sub"), dataFile))
+      assertThatCode(() -> checkFsRead(enforcer, caller("com.example.app.sub"), dataFile))
           .doesNotThrowAnyException();
     }
 
@@ -76,7 +77,7 @@ class PolicyEnforcerTest {
 
       PolicyEnforcer enforcer = createEnforcer(policy);
 
-      assertThatThrownBy(() -> enforcer.checkFsRead(caller("com.example.app"), dataFile))
+      assertThatThrownBy(() -> checkFsRead(enforcer, caller("com.example.app"), dataFile))
           .isInstanceOf(SecurityException.class)
           .hasMessageContaining("access denied")
           .hasMessageContaining("fs.read");
@@ -89,7 +90,7 @@ class PolicyEnforcerTest {
 
       PolicyEnforcer enforcer = createEnforcer(policy);
 
-      assertThatThrownBy(() -> enforcer.checkFsRead(caller("com.example.app"), outsideFile))
+      assertThatThrownBy(() -> checkFsRead(enforcer, caller("com.example.app"), outsideFile))
           .isInstanceOf(SecurityException.class)
           .hasMessageContaining("access denied");
     }
@@ -109,7 +110,7 @@ class PolicyEnforcerTest {
 
       PolicyEnforcer enforcer = createEnforcer(policy);
 
-      assertThatCode(() -> enforcer.checkFsRead(caller("com.example.app.io"), dataFile))
+      assertThatCode(() -> checkFsRead(enforcer, caller("com.example.app.io"), dataFile))
           .doesNotThrowAnyException();
     }
 
@@ -123,7 +124,7 @@ class PolicyEnforcerTest {
 
       PolicyEnforcer enforcer = createEnforcer(policy);
 
-      assertThatThrownBy(() -> enforcer.checkFsRead(caller("com.example.app.io.impl"), dataFile))
+      assertThatThrownBy(() -> checkFsRead(enforcer, caller("com.example.app.io.impl"), dataFile))
           .isInstanceOf(SecurityException.class);
     }
 
@@ -137,7 +138,7 @@ class PolicyEnforcerTest {
 
       PolicyEnforcer enforcer = createEnforcer(policy);
 
-      assertThatThrownBy(() -> enforcer.checkFsRead(caller("com.example.app.other"), dataFile))
+      assertThatThrownBy(() -> checkFsRead(enforcer, caller("com.example.app.other"), dataFile))
           .isInstanceOf(SecurityException.class);
     }
   }
@@ -156,7 +157,7 @@ class PolicyEnforcerTest {
 
       PolicyEnforcer enforcer = createEnforcer(policy);
 
-      assertThatCode(() -> enforcer.checkFsRead(caller("com.example.app.io"), dataFile))
+      assertThatCode(() -> checkFsRead(enforcer, caller("com.example.app.io"), dataFile))
           .doesNotThrowAnyException();
     }
 
@@ -170,9 +171,9 @@ class PolicyEnforcerTest {
 
       PolicyEnforcer enforcer = createEnforcer(policy);
 
-      assertThatCode(() -> enforcer.checkFsRead(caller("com.example.app.io.impl"), dataFile))
+      assertThatCode(() -> checkFsRead(enforcer, caller("com.example.app.io.impl"), dataFile))
           .doesNotThrowAnyException();
-      assertThatCode(() -> enforcer.checkFsRead(caller("com.example.app.io.impl.deep"), dataFile))
+      assertThatCode(() -> checkFsRead(enforcer, caller("com.example.app.io.impl.deep"), dataFile))
           .doesNotThrowAnyException();
     }
 
@@ -186,7 +187,7 @@ class PolicyEnforcerTest {
 
       PolicyEnforcer enforcer = createEnforcer(policy);
 
-      assertThatThrownBy(() -> enforcer.checkFsRead(caller("com.example.app.other"), dataFile))
+      assertThatThrownBy(() -> checkFsRead(enforcer, caller("com.example.app.other"), dataFile))
           .isInstanceOf(SecurityException.class);
     }
   }
@@ -205,9 +206,9 @@ class PolicyEnforcerTest {
 
       PolicyEnforcer enforcer = createEnforcer(policy);
 
-      assertThatCode(() -> enforcer.checkFsRead(caller("com.example.app.io"), dataFile))
+      assertThatCode(() -> checkFsRead(enforcer, caller("com.example.app.io"), dataFile))
           .doesNotThrowAnyException();
-      assertThatCode(() -> enforcer.checkFsRead(caller("com.example.app.worker"), dataFile))
+      assertThatCode(() -> checkFsRead(enforcer, caller("com.example.app.worker"), dataFile))
           .doesNotThrowAnyException();
     }
 
@@ -221,7 +222,7 @@ class PolicyEnforcerTest {
 
       PolicyEnforcer enforcer = createEnforcer(policy);
 
-      assertThatThrownBy(() -> enforcer.checkFsRead(caller("com.example.app"), dataFile))
+      assertThatThrownBy(() -> checkFsRead(enforcer, caller("com.example.app"), dataFile))
           .isInstanceOf(SecurityException.class);
     }
 
@@ -235,7 +236,7 @@ class PolicyEnforcerTest {
 
       PolicyEnforcer enforcer = createEnforcer(policy);
 
-      assertThatThrownBy(() -> enforcer.checkFsRead(caller("com.example.app.io.impl"), dataFile))
+      assertThatThrownBy(() -> checkFsRead(enforcer, caller("com.example.app.io.impl"), dataFile))
           .isInstanceOf(SecurityException.class);
     }
   }
@@ -253,7 +254,7 @@ class PolicyEnforcerTest {
 
       PolicyEnforcer enforcer = createEnforcer(policy);
 
-      assertThatCode(() -> enforcer.checkFsRead(caller("com.example.app"), jsonFile))
+      assertThatCode(() -> checkFsRead(enforcer, caller("com.example.app"), jsonFile))
           .doesNotThrowAnyException();
     }
 
@@ -266,7 +267,7 @@ class PolicyEnforcerTest {
 
       PolicyEnforcer enforcer = createEnforcer(policy);
 
-      assertThatThrownBy(() -> enforcer.checkFsRead(caller("com.example.app"), xmlFile))
+      assertThatThrownBy(() -> checkFsRead(enforcer, caller("com.example.app"), xmlFile))
           .isInstanceOf(SecurityException.class);
     }
 
@@ -278,7 +279,7 @@ class PolicyEnforcerTest {
 
       PolicyEnforcer enforcer = createEnforcer(policy);
 
-      assertThatCode(() -> enforcer.checkFsRead(caller("com.example.app"), dataSubFile))
+      assertThatCode(() -> checkFsRead(enforcer, caller("com.example.app"), dataSubFile))
           .doesNotThrowAnyException();
     }
   }
@@ -295,11 +296,11 @@ class PolicyEnforcerTest {
       PolicyEnforcer enforcer = createEnforcer(policy);
 
       // First call
-      assertThatCode(() -> enforcer.checkFsRead(caller("com.example.app"), dataFile))
+      assertThatCode(() -> checkFsRead(enforcer, caller("com.example.app"), dataFile))
           .doesNotThrowAnyException();
 
       // Second call should hit cache
-      assertThatCode(() -> enforcer.checkFsRead(caller("com.example.app"), dataFile))
+      assertThatCode(() -> checkFsRead(enforcer, caller("com.example.app"), dataFile))
           .doesNotThrowAnyException();
     }
 
@@ -311,11 +312,11 @@ class PolicyEnforcerTest {
       PolicyEnforcer enforcer = createEnforcer(policy);
 
       // First call
-      assertThatThrownBy(() -> enforcer.checkFsRead(caller("com.example.app"), dataFile))
+      assertThatThrownBy(() -> checkFsRead(enforcer, caller("com.example.app"), dataFile))
           .isInstanceOf(SecurityException.class);
 
       // Second call should hit cache
-      assertThatThrownBy(() -> enforcer.checkFsRead(caller("com.example.app"), dataFile))
+      assertThatThrownBy(() -> checkFsRead(enforcer, caller("com.example.app"), dataFile))
           .isInstanceOf(SecurityException.class);
     }
   }
@@ -333,7 +334,7 @@ class PolicyEnforcerTest {
 
       // Module matches policy module
       assertThatCode(
-              () -> enforcer.checkFsRead(caller("com.example.app", "com.example.app"), dataFile))
+              () -> checkFsRead(enforcer, caller("com.example.app", "com.example.app"), dataFile))
           .doesNotThrowAnyException();
     }
 
@@ -345,7 +346,7 @@ class PolicyEnforcerTest {
       PolicyEnforcer enforcer = createEnforcer(policy);
 
       // Unnamed modules (classpath) are allowed - package check still applies
-      assertThatCode(() -> enforcer.checkFsRead(caller("com.example.app", "unnamed"), dataFile))
+      assertThatCode(() -> checkFsRead(enforcer, caller("com.example.app", "unnamed"), dataFile))
           .doesNotThrowAnyException();
     }
 
@@ -359,7 +360,8 @@ class PolicyEnforcerTest {
       // Module mismatch - even if package matches, should be denied
       assertThatThrownBy(
               () ->
-                  enforcer.checkFsRead(caller("com.example.app", "com.malicious.module"), dataFile))
+                  checkFsRead(
+                      enforcer, caller("com.example.app", "com.malicious.module"), dataFile))
           .isInstanceOf(SecurityException.class)
           .hasMessageContaining("module")
           .hasMessageContaining("com.malicious.module");
@@ -377,7 +379,7 @@ class PolicyEnforcerTest {
 
       PolicyEnforcer enforcer = createEnforcer(policy);
 
-      assertThatThrownBy(() -> enforcer.checkFsRead(caller("com.example.app.io"), dataFile))
+      assertThatThrownBy(() -> checkFsRead(enforcer, caller("com.example.app.io"), dataFile))
           .hasMessageContaining("com.example.app.io");
     }
 
@@ -388,7 +390,7 @@ class PolicyEnforcerTest {
 
       PolicyEnforcer enforcer = createEnforcer(policy);
 
-      assertThatThrownBy(() -> enforcer.checkFsRead(caller("com.example.app"), dataFile))
+      assertThatThrownBy(() -> checkFsRead(enforcer, caller("com.example.app"), dataFile))
           .hasMessageContaining("fs.read");
     }
 
@@ -400,7 +402,7 @@ class PolicyEnforcerTest {
 
       PolicyEnforcer enforcer = createEnforcer(policy);
 
-      assertThatThrownBy(() -> enforcer.checkFsRead(caller("com.example.app"), secretFile))
+      assertThatThrownBy(() -> checkFsRead(enforcer, caller("com.example.app"), secretFile))
           .hasMessageContaining("secret.txt");
     }
   }
@@ -442,5 +444,13 @@ class PolicyEnforcerTest {
   /** Creates a CallerContext for the default module (com.example.app). */
   private CallerContext caller(String packageName) {
     return caller(packageName, "com.example.app");
+  }
+
+  /** Helper to call check() and throw if denied, for test readability. */
+  private static void checkFsRead(PolicyEnforcer enforcer, CallerContext caller, Path path) {
+    SecurityException denial = enforcer.check(caller, Operation.FS_READ, path, 0);
+    if (denial != null) {
+      throw denial;
+    }
   }
 }


### PR DESCRIPTION
## Description
  
  Reduce boilerplate when adding new capabilities by introducing
  category-based dispatch in PolicyEnforcer and BootstrapEnforcer.

  Changes:
  - Operation enum now includes capabilityName() and category()
  - Four categories: FILESYSTEM, SIMPLE, PORT, TARGET_PATTERN
  - PolicyEnforcer switches on category, not individual operations
  - Adding a capability with existing category requires 0 PolicyEnforcer changes
  - Updated CONTRIBUTING.md with simplified 4-step process
  - Updated README files to reflect current capabilities

  Adding threads.create now requires ~31 lines vs ~66 lines before.
