### PR TITLE
Document external policy files and add post-v0.1.0 roadmap

### DIFF
--- a/DEVELOPMENT_PLAN.md
+++ b/DEVELOPMENT_PLAN.md
@@ -254,6 +254,69 @@ Exit criteria:
 
 ---
 
+## Post-v0.1.0 Roadmap
+
+### M7 — Policy Hot Reload
+
+Enable policy updates without JVM restart:
+
+* File watcher for policy.bin changes (configurable interval or inotify)
+* Atomic PolicyEnforcer swap (volatile reference)
+* Decision cache invalidation on reload
+* Reload event logging and metrics
+* Optional: SIGHUP trigger for manual reload
+
+Implementation:
+
+```java
+// PolicyReloader watches for file changes
+public class PolicyReloader {
+  private final Path policyPath;
+  private final AtomicReference<PolicyEnforcer> enforcerRef;
+
+  public void onFileChanged() {
+    PolicyDescriptor newPolicy = BinaryPolicyReader.fromFile(policyPath);
+    PolicyEnforcer newEnforcer = new PolicyEnforcer(newPolicy, config);
+    enforcerRef.set(newEnforcer);
+    LOG.info("Policy reloaded: {}", policyPath);
+  }
+}
+```
+
+Exit criteria:
+
+* Policy changes take effect within configurable interval (default: 5s)
+* No restart required for entitlement updates
+* Thread-safe reload with no missed enforcement
+
+---
+
+### M8 — Additional Capabilities
+
+* `threads.create` — thread creation control
+* `native.load` — native library loading control
+* `process.exec` — subprocess execution control
+
+These use existing category infrastructure (SIMPLE or TARGET_PATTERN).
+
+---
+
+### M9 — Reflection Control
+
+* `reflect.invoke` — method invocation via reflection
+* `reflect.access` — setAccessible() control
+* Design decision: coarse (SIMPLE) vs fine-grained (TARGET_PATTERN with class patterns)
+
+Instrumented APIs:
+
+* `Method.invoke()`
+* `Field.get/set()`
+* `Constructor.newInstance()`
+* `AccessibleObject.setAccessible()`
+* `MethodHandle.invoke()` family
+
+---
+
 ## Initial capability set (v0.1.0)
 
 * `fs.read(root, glob)`

--- a/README.md
+++ b/README.md
@@ -223,13 +223,23 @@ module com.example.myapp {
 
 ### 4. Production deployment
 
+For production, use an external policy file so administrators can update entitlements without rebuilding:
+
 ```bash
-java -javaagent:jguard-agent.jar=policy.bin \
+# Compile policy separately
+jguard compile module-info.jguard -o /etc/myapp/policy.bin
+
+# Run with external policy
+java -javaagent:jguard-agent.jar=/etc/myapp/policy.bin \
      -Djguard.mode=strict \
      -jar your-app.jar
+
+# Update entitlements without rebuild (restart required)
+jguard compile updated-policy.jguard -o /etc/myapp/policy.bin
+systemctl restart myapp
 ```
 
-See [gradle-plugin/README.md](gradle-plugin/README.md) for full plugin documentation.
+See [agent/README.md](agent/README.md) for full agent documentation and [gradle-plugin/README.md](gradle-plugin/README.md) for build integration.
 
 ---
 

--- a/agent/README.md
+++ b/agent/README.md
@@ -37,6 +37,27 @@ This separation is necessary because advice woven into JDK classes can only refe
 -javaagent:jguard-agent.jar=/path/to/policy.bin
 ```
 
+### External Policy Files (Recommended for Production)
+
+For production deployments, keep policy files external to the application JAR. This allows administrators to update entitlements without rebuilding the application:
+
+```bash
+# 1. Compile policy separately
+jguard compile src/main/java/module-info.jguard -o /etc/myapp/policy.bin
+
+# 2. Run application with external policy
+java -javaagent:jguard-agent.jar=/etc/myapp/policy.bin -jar myapp.jar
+
+# 3. Update entitlements (requires restart, no rebuild)
+jguard compile updated-policy.jguard -o /etc/myapp/policy.bin
+systemctl restart myapp
+```
+
+This separation enables:
+- **Security team** manages policy files independently
+- **Dev team** ships application without embedded policies
+- **Ops team** updates entitlements without rebuilding artifacts
+
 ### System Properties
 
 | Property | Values | Default | Description |


### PR DESCRIPTION
## Description
  Add documentation for external policy file deployment, which allows
  administrators to update entitlements without rebuilding the application:

  - agent/README.md: New "External Policy Files" section with examples
  - README.md: Updated production deployment section

  Add post-v0.1.0 roadmap to DEVELOPMENT_PLAN.md:

  - M7: Policy Hot Reload (file watcher, atomic swap, no restart)
  - M8: Additional Capabilities (threads.create, native.load, process.exec)
  - M9: Reflection Control (reflect.invoke, reflect.access)
