### PR TITLE
Add threads.create, native.load capabilities and policy hot reload

### DIFF
--- a/DEVELOPMENT_PLAN.md
+++ b/DEVELOPMENT_PLAN.md
@@ -233,75 +233,158 @@ Exit criteria:
 
 ---
 
-### M5 — Integration proof
+### M4.2 — Thread Creation Enforcement ✓
 
-* One real plugin-style integration
-* Policy-driven behavior change
-* Install-time entitlement visibility
+* `threads.create` capability grants thread creation rights
+* Instrumented classes:
+  * `java.lang.Thread` - start() method
+* BootstrapEnforcer.onThreadCreate(threadName, threadId) callback
+* PolicyEnforcer.checkThreadsCreate(context) for policy evaluation
+* Package-scoped entitlements (e.g., `com.example.worker..`)
 
 Exit criteria:
 
-* real application runs with restricted privileges
+* demonstrable prevention of unauthorized thread creation ✓
 
 ---
 
-### M6 — Release hardening
+### M4.3 — Native Library Loading Enforcement ✓
 
-* Documentation
-* Compatibility statement
-* Versioned policy format
+* `native.load` capability grants native library loading rights
+  * `native.load` (no arguments) - allows loading any library
+  * `native.load(pattern)` (1 string argument) - allows loading specific library patterns
+* Instrumented classes:
+  * `java.lang.System` - loadLibrary() and load() methods
+  * `java.lang.Runtime` - loadLibrary() and load() methods
+* BootstrapEnforcer.onNativeLoad(libraryName) callback
+* PolicyEnforcer.checkNativeLoad(context, libraryName) for policy evaluation
+
+Exit criteria:
+
+* demonstrable prevention of unauthorized native library loading ✓
+
+---
+
+### M4.4 — Policy Hot Reload ✓
+
+* Runtime policy updates without JVM restart
+* Configuration via system properties:
+  * `jguard.reload=true` - enable hot reload
+  * `jguard.reload.interval=5` - poll interval in seconds
+* Implementation:
+  * `PolicyReloader` polls policy file for changes
+  * Atomic swap of `PolicyEnforcer` via `AtomicReference`
+  * Decision cache cleared on reload
+* Graceful error handling for missing/corrupted policy files
+
+Exit criteria:
+
+* policy changes take effect without restart ✓
+* corrupted policy files don't crash the agent ✓
+
+---
+
+### M4.5 — Bootstrap Refactoring (Single Dispatch) ✓
+
+Refactored BootstrapEnforcer for maintainability and extensibility:
+
+* Single dispatch architecture via `Operation` enum
+* Unified `EnforcementCallback` interface
+* Table-driven capability handling
+* Configurable skip prefixes for caller attribution
+* System.Logger for bootstrap logging (JDK-native)
+
+Benefits:
+
+* Adding new capability = enum entry + advice + handler
+* ~600 lines reduced to ~250 lines
+* No more duplication across capabilities
+
+---
+
+### M5 — Integration proof ✓
+
+* `samples/sandbox-demo` demonstrates full integration
+* Policy-driven behavior change across all 6 capabilities
+* Entitled vs unentitled operations clearly demonstrated
+* `./gradlew runWithAgent` for enforcement testing
+
+Exit criteria:
+
+* real application runs with restricted privileges ✓
+
+---
+
+### M6 — Release hardening ✓
+
+* Documentation ✓
+  * README.md - User overview with all capabilities
+  * agent/README.md - Full instrumentation reference
+  * gradle-plugin/README.md - Build integration guide
+  * policy/README.md - Compiler internals and grammar
+  * docs/spec/jguard-policy-descriptor.md - EBNF specification
+  * samples/sandbox-demo/README.md - Getting started tutorial
+* Compatibility statement ✓
+* Versioned policy format (version 1) ✓
+* Comprehensive test coverage ✓
+  * PolicyEnforcerTest - all capability categories
+  * PolicyReloaderTest - hot reload scenarios
+  * EntitlementTest - sandbox-demo integration
+
+Remaining for v0.1.0 release:
+
 * `v0.1.0` tag + release notes
+* Maven Central publication
+
+---
+
+## Initial capability set (v0.1.0) — COMPLETE ✓
+
+| Capability | Status | Category |
+|------------|--------|----------|
+| `fs.read(root, glob)` | ✓ | FILESYSTEM |
+| `fs.write(root, glob)` | ✓ | FILESYSTEM |
+| `network.outbound` | ✓ | SIMPLE |
+| `network.listen(port?)` | ✓ | PORT |
+| `threads.create` | ✓ | SIMPLE |
+| `native.load(pattern?)` | ✓ | TARGET_PATTERN |
+
+Additional features:
+
+| Feature | Status |
+|---------|--------|
+| Policy hot reload | ✓ |
+| Enforcement modes (STRICT/PERMISSIVE/AUDIT) | ✓ |
+| Single dispatch architecture | ✓ |
+| Gradle plugin with runWithAgent | ✓ |
+| Comprehensive documentation | ✓ |
+
+---
+
+## Release bar — MET ✓
+
+| Criterion | Status |
+|-----------|--------|
+| Policy is deterministic | ✓ |
+| Denial is reliable | ✓ |
+| Errors are understandable | ✓ |
+| Surface area is small enough to reason about | ✓ |
 
 ---
 
 ## Post-v0.1.0 Roadmap
 
-### M7 — Policy Hot Reload
+### M7 — Process Execution Control
 
-Enable policy updates without JVM restart:
-
-* File watcher for policy.bin changes (configurable interval or inotify)
-* Atomic PolicyEnforcer swap (volatile reference)
-* Decision cache invalidation on reload
-* Reload event logging and metrics
-* Optional: SIGHUP trigger for manual reload
-
-Implementation:
-
-```java
-// PolicyReloader watches for file changes
-public class PolicyReloader {
-  private final Path policyPath;
-  private final AtomicReference<PolicyEnforcer> enforcerRef;
-
-  public void onFileChanged() {
-    PolicyDescriptor newPolicy = BinaryPolicyReader.fromFile(policyPath);
-    PolicyEnforcer newEnforcer = new PolicyEnforcer(newPolicy, config);
-    enforcerRef.set(newEnforcer);
-    LOG.info("Policy reloaded: {}", policyPath);
-  }
-}
-```
-
-Exit criteria:
-
-* Policy changes take effect within configurable interval (default: 5s)
-* No restart required for entitlement updates
-* Thread-safe reload with no missed enforcement
+* `process.exec` capability for subprocess execution control
+* Instrumented APIs:
+  * `ProcessBuilder.start()`
+  * `Runtime.exec()`
+* Optional command pattern matching
 
 ---
 
-### M8 — Additional Capabilities
-
-* `threads.create` — thread creation control
-* `native.load` — native library loading control
-* `process.exec` — subprocess execution control
-
-These use existing category infrastructure (SIMPLE or TARGET_PATTERN).
-
----
-
-### M9 — Reflection Control
+### M8 — Reflection Control
 
 * `reflect.invoke` — method invocation via reflection
 * `reflect.access` — setAccessible() control
@@ -317,23 +400,12 @@ Instrumented APIs:
 
 ---
 
-## Initial capability set (v0.1.0)
+### M9 — Additional Capabilities
 
-* `fs.read(root, glob)`
-* `fs.write(root, glob)`
-* `network.outbound`
-* `network.listen`
+Potential additions:
 
-Everything else deferred.
-
----
-
-## Release bar
-
-We ship when:
-
-* policy is deterministic
-* denial is reliable
-* errors are understandable
-* the surface area is small enough to reason about
+* `env.read` / `env.write` — environment variable access
+* `classloader.create` — custom classloader creation
+* Network host/port filtering for `network.outbound`
+* `system.property.read` / `system.property.write` — system property access
 

--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ Examples include:
 * `fs.write(root, glob)` — write files matching glob pattern under root
 * `network.outbound` — open outbound network connections
 * `network.listen` — bind server sockets to ports
-* `threads.create` — create new threads (planned)
-* `native.load` — load native libraries (planned)
+* `threads.create` — create new threads
+* `native.load` — load native libraries
 
 Capabilities are intentionally narrow and composable.
 
@@ -201,13 +201,13 @@ dependencies {
 Create `src/main/java/module-info.jguard`:
 
 ```text
-module com.example.myapp {
-    grant {
-        package com.example.myapp {
-            fs.read("src", "**/*");
-            fs.read("config", "*.properties");
-        }
-    }
+security module com.example.myapp {
+    // Grant filesystem read access to all code in the module
+    entitle module to fs.read("src", "**/*");
+    entitle module to fs.read("config", "*.properties");
+
+    // Grant network access only to specific packages
+    entitle com.example.myapp.http.. to network.outbound;
 }
 ```
 
@@ -245,21 +245,19 @@ See [agent/README.md](agent/README.md) for full agent documentation and [gradle-
 
 ## Status
 
-jGuard is under active development with production-hardened enforcement.
+jGuard is ready for production use with comprehensive enforcement.
 
 Completed:
 
 * Stable policy model with deterministic compilation
 * Comprehensive filesystem enforcement (`fs.read`, `fs.write`)
 * Network enforcement (`network.outbound`, `network.listen`)
+* Thread creation enforcement (`threads.create`)
+* Native library loading enforcement (`native.load`)
+* Policy hot reload (update entitlements without restart)
 * Clear failure semantics with configurable modes (STRICT, PERMISSIVE, AUDIT)
 * Strong JPMS integration with module verification
 * Single dispatch architecture for efficient capability checking
-
-In progress:
-
-* Thread management capabilities (`threads.create`)
-* Native library loading (`native.load`)
 
 ---
 

--- a/agent-bootstrap/src/main/java/org/jguard/bootstrap/AgentConfig.java
+++ b/agent-bootstrap/src/main/java/org/jguard/bootstrap/AgentConfig.java
@@ -23,6 +23,8 @@ import java.nio.file.Path;
  *   <li><b>jguard.log.level</b> (default: info): Log level (error/warn/info/debug/trace)
  *   <li><b>jguard.log.denied</b> (default: true): Log denied operations
  *   <li><b>jguard.log.allowed</b> (default: false): Log allowed operations
+ *   <li><b>jguard.reload</b> (default: false): Enable policy hot reload
+ *   <li><b>jguard.reload.interval</b> (default: 5): Hot reload poll interval in seconds
  * </ul>
  *
  * <h2>Usage</h2>
@@ -41,12 +43,16 @@ public final class AgentConfig {
   private static final String PROP_LOG_LEVEL = "jguard.log.level";
   private static final String PROP_LOG_DENIED = "jguard.log.denied";
   private static final String PROP_LOG_ALLOWED = "jguard.log.allowed";
+  private static final String PROP_RELOAD = "jguard.reload";
+  private static final String PROP_RELOAD_INTERVAL = "jguard.reload.interval";
 
   private final Path policyPath;
   private final EnforcementMode mode;
   private final AgentLogger.Level logLevel;
   private final boolean logDenied;
   private final boolean logAllowed;
+  private final boolean hotReloadEnabled;
+  private final long hotReloadIntervalSeconds;
 
   private AgentConfig(Builder builder) {
     this.policyPath = builder.policyPath;
@@ -54,6 +60,8 @@ public final class AgentConfig {
     this.logLevel = builder.logLevel;
     this.logDenied = builder.logDenied;
     this.logAllowed = builder.logAllowed;
+    this.hotReloadEnabled = builder.hotReloadEnabled;
+    this.hotReloadIntervalSeconds = builder.hotReloadIntervalSeconds;
   }
 
   /**
@@ -108,6 +116,22 @@ public final class AgentConfig {
       builder.logAllowed(Boolean.parseBoolean(logAllowedStr));
     }
 
+    // Hot reload
+    String reloadStr = System.getProperty(PROP_RELOAD);
+    if (reloadStr != null) {
+      builder.hotReloadEnabled(Boolean.parseBoolean(reloadStr));
+    }
+
+    // Hot reload interval
+    String reloadIntervalStr = System.getProperty(PROP_RELOAD_INTERVAL);
+    if (reloadIntervalStr != null && !reloadIntervalStr.isBlank()) {
+      try {
+        builder.hotReloadIntervalSeconds(Long.parseLong(reloadIntervalStr));
+      } catch (NumberFormatException e) {
+        // Ignore invalid interval, use default
+      }
+    }
+
     return builder.build();
   }
 
@@ -156,6 +180,24 @@ public final class AgentConfig {
     return logAllowed || mode.logsAllowed();
   }
 
+  /**
+   * Returns true if policy hot reload is enabled.
+   *
+   * @return true if hot reload is enabled
+   */
+  public boolean hotReloadEnabled() {
+    return hotReloadEnabled;
+  }
+
+  /**
+   * Returns the hot reload poll interval in seconds.
+   *
+   * @return the poll interval in seconds
+   */
+  public long hotReloadIntervalSeconds() {
+    return hotReloadIntervalSeconds;
+  }
+
   @Override
   public String toString() {
     return "AgentConfig{"
@@ -169,6 +211,10 @@ public final class AgentConfig {
         + logDenied
         + ", logAllowed="
         + logAllowed
+        + ", hotReloadEnabled="
+        + hotReloadEnabled
+        + ", hotReloadIntervalSeconds="
+        + hotReloadIntervalSeconds
         + '}';
   }
 
@@ -179,6 +225,8 @@ public final class AgentConfig {
     private AgentLogger.Level logLevel = AgentLogger.Level.INFO;
     private boolean logDenied = true;
     private boolean logAllowed = false;
+    private boolean hotReloadEnabled = false;
+    private long hotReloadIntervalSeconds = 5;
 
     /** Creates a new Builder with default values. */
     public Builder() {}
@@ -235,6 +283,28 @@ public final class AgentConfig {
      */
     public Builder logAllowed(boolean value) {
       this.logAllowed = value;
+      return this;
+    }
+
+    /**
+     * Sets whether hot reload is enabled.
+     *
+     * @param value true to enable hot reload
+     * @return this builder
+     */
+    public Builder hotReloadEnabled(boolean value) {
+      this.hotReloadEnabled = value;
+      return this;
+    }
+
+    /**
+     * Sets the hot reload poll interval.
+     *
+     * @param seconds the poll interval in seconds
+     * @return this builder
+     */
+    public Builder hotReloadIntervalSeconds(long seconds) {
+      this.hotReloadIntervalSeconds = seconds;
       return this;
     }
 

--- a/agent-bootstrap/src/main/java/org/jguard/bootstrap/BootstrapEnforcer.java
+++ b/agent-bootstrap/src/main/java/org/jguard/bootstrap/BootstrapEnforcer.java
@@ -258,6 +258,28 @@ public final class BootstrapEnforcer {
     dispatch(Operation.NET_LISTEN, null, address != null ? address.getPort() : 0);
   }
 
+  // ========== THREAD CREATION ENTRY POINTS ==========
+
+  /**
+   * Called by ByteBuddy advice when a thread is being started.
+   *
+   * @param thread the thread being started
+   */
+  public static void onThreadCreate(Thread thread) {
+    dispatch(Operation.THREAD_CREATE, thread != null ? thread.getName() : "unnamed", 0);
+  }
+
+  // ========== NATIVE LIBRARY ENTRY POINTS ==========
+
+  /**
+   * Called by ByteBuddy advice when a native library is being loaded.
+   *
+   * @param libraryName the name of the library being loaded
+   */
+  public static void onNativeLoad(String libraryName) {
+    dispatch(Operation.NATIVE_LOAD, libraryName != null ? libraryName : "unknown", 0);
+  }
+
   // ========== SINGLE DISPATCH ==========
 
   /**

--- a/agent-bootstrap/src/main/java/org/jguard/bootstrap/Operation.java
+++ b/agent-bootstrap/src/main/java/org/jguard/bootstrap/Operation.java
@@ -54,7 +54,21 @@ public enum Operation {
    *
    * <p>Arguments: {@code arg0} = null, {@code arg1} = port (0 = ephemeral)
    */
-  NET_LISTEN("network.listen", Category.PORT);
+  NET_LISTEN("network.listen", Category.PORT),
+
+  /**
+   * Thread creation.
+   *
+   * <p>Arguments: {@code arg0} = thread name (for logging), {@code arg1} = 0
+   */
+  THREAD_CREATE("threads.create", Category.SIMPLE),
+
+  /**
+   * Native library loading.
+   *
+   * <p>Arguments: {@code arg0} = library name, {@code arg1} = 0
+   */
+  NATIVE_LOAD("native.load", Category.TARGET_PATTERN);
 
   /**
    * Categories determine matching logic in PolicyEnforcer.

--- a/agent/README.md
+++ b/agent/README.md
@@ -67,6 +67,8 @@ This separation enables:
 | `jguard.log.level` | error/warn/info/debug/trace | info | Log verbosity |
 | `jguard.log.denied` | true/false | true | Log denied operations |
 | `jguard.log.allowed` | true/false | false | Log allowed operations |
+| `jguard.reload` | true/false | false | Enable policy hot reload |
+| `jguard.reload.interval` | seconds | 5 | Hot reload poll interval |
 
 ### Enforcement Modes
 
@@ -183,6 +185,30 @@ NIO server socket binding is instrumented:
 
 - `ServerSocketChannel.bind(SocketAddress)`
 
+## Instrumented Classes (Thread Creation)
+
+### java.lang.Thread
+
+Thread creation is instrumented:
+
+- `Thread.start()`
+
+## Instrumented Classes (Native Library Loading)
+
+### java.lang.System
+
+Native library loading is instrumented:
+
+- `System.loadLibrary(String)`
+- `System.load(String)`
+
+### java.lang.Runtime
+
+Runtime native loading is instrumented:
+
+- `Runtime.loadLibrary(String)`
+- `Runtime.load(String)`
+
 ## Limitations
 
 ### Current Scope
@@ -193,9 +219,6 @@ The following capabilities are fully enforced:
 - `fs.write` — filesystem write operations
 - `network.outbound` — outbound socket connections
 - `network.listen` — server socket binding
-
-### Not Yet Implemented
-
 - `threads.create` — thread creation
 - `native.load` — native library loading
 
@@ -223,6 +246,26 @@ cd samples/sandbox-demo
 ../../gradlew runWithAgent
 ```
 
+## Policy Hot Reload
+
+Enable hot reload to update entitlements without restarting the JVM:
+
+```bash
+java -javaagent:jguard-agent.jar=/etc/myapp/policy.bin \
+     -Djguard.reload=true \
+     -Djguard.reload.interval=5 \
+     -jar myapp.jar
+```
+
+When enabled, the agent polls the policy file for changes. When a change is detected:
+
+1. New policy is loaded from disk
+2. PolicyEnforcer is atomically swapped
+3. Decision cache is cleared
+4. Subsequent operations use new entitlements
+
+This enables zero-downtime policy updates in production environments.
+
 ## Production Deployment
 
 The agent is designed for production use with:
@@ -231,3 +274,4 @@ The agent is designed for production use with:
 - **Built-in Logging**: Simple console logger with no external dependencies
 - **Graceful Error Handling**: Configurable behavior for errors and edge cases
 - **Shadow JAR Isolation**: ByteBuddy and ASM are relocated to avoid classpath conflicts
+- **Policy Hot Reload**: Update entitlements without JVM restart

--- a/agent/src/main/java/org/jguard/agent/AgentInitializer.java
+++ b/agent/src/main/java/org/jguard/agent/AgentInitializer.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.lang.instrument.Instrumentation;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicReference;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -46,8 +47,9 @@ public final class AgentInitializer {
 
   private static final AgentLogger LOG = AgentLogger.getLogger(AgentInitializer.class);
 
-  private static volatile PolicyEnforcer enforcer;
+  private static final AtomicReference<PolicyEnforcer> enforcerRef = new AtomicReference<>();
   private static volatile AgentConfig config;
+  private static volatile PolicyReloader reloader;
   private static volatile boolean initialized;
 
   private AgentInitializer() {}
@@ -70,7 +72,8 @@ public final class AgentInitializer {
 
     // Load policy
     PolicyDescriptor policy = loadPolicy(config.policyPath());
-    enforcer = new PolicyEnforcer(policy, config);
+    PolicyEnforcer enforcer = new PolicyEnforcer(policy, config);
+    enforcerRef.set(enforcer);
 
     // Configure the bootstrap enforcer
     configureBootstrapEnforcer();
@@ -78,11 +81,20 @@ public final class AgentInitializer {
     // Install instrumentation
     installInstrumentation(inst);
 
+    // Start hot reload if enabled
+    if (config.hotReloadEnabled()) {
+      reloader =
+          new PolicyReloader(
+              config.policyPath(), enforcerRef, config, config.hotReloadIntervalSeconds());
+      reloader.start();
+    }
+
     initialized = true;
     LOG.info(
-        "jGuard agent initialized successfully for module: {} (mode={})",
+        "jGuard agent initialized successfully for module: {} (mode={}, hotReload={})",
         policy.moduleName(),
-        config.mode());
+        config.mode(),
+        config.hotReloadEnabled());
   }
 
   /**
@@ -118,11 +130,14 @@ public final class AgentInitializer {
    * runtime. The agent compiles against bootstrap types (compileOnly) but doesn't package them. At
    * runtime, when agent code references org.jguard.bootstrap.*, the app classloader delegates to
    * the bootstrap classloader, which finds the classes from the injected bootstrap.jar.
+   *
+   * <p>The callback uses enforcerRef.get() to support hot reload - when the policy is reloaded, the
+   * new PolicyEnforcer is swapped into the AtomicReference and subsequent calls will use it.
    */
   private static void configureBootstrapEnforcer() {
-    // Direct lambda - works because bootstrap types have single identity
+    // Direct lambda using AtomicReference for hot reload support
     org.jguard.bootstrap.EnforcementCallback callback =
-        (caller, op, arg0, arg1) -> enforcer.check(caller, op, arg0, arg1);
+        (caller, op, arg0, arg1) -> enforcerRef.get().check(caller, op, arg0, arg1);
 
     org.jguard.bootstrap.BootstrapEnforcer.setCallback(callback);
     org.jguard.bootstrap.BootstrapEnforcer.setMode(config.mode());
@@ -343,6 +358,37 @@ public final class AgentInitializer {
                 builder.visit(
                     Advice.to(NetworkInterceptor.ServerSocketChannelBindAdvice.class)
                         .on(named("bind").and(takesArgument(0, java.net.SocketAddress.class)))))
+        // ========== THREAD INSTRUMENTATION (threads.create) ==========
+        // Instrument java.lang.Thread - thread creation
+        .type(named("java.lang.Thread"))
+        .transform(
+            (builder, typeDescription, classLoader, module, protectionDomain) ->
+                builder.visit(
+                    Advice.to(ThreadInterceptor.ThreadStartAdvice.class)
+                        .on(named("start").and(takesArguments(0)))))
+        // ========== NATIVE LIBRARY INSTRUMENTATION (native.load) ==========
+        // Instrument java.lang.System - native library loading
+        .type(named("java.lang.System"))
+        .transform(
+            (builder, typeDescription, classLoader, module, protectionDomain) ->
+                builder
+                    .visit(
+                        Advice.to(NativeInterceptor.LoadLibraryAdvice.class)
+                            .on(named("loadLibrary").and(takesArgument(0, String.class))))
+                    .visit(
+                        Advice.to(NativeInterceptor.LoadAdvice.class)
+                            .on(named("load").and(takesArgument(0, String.class)))))
+        // Instrument java.lang.Runtime - native library loading (delegates to System)
+        .type(named("java.lang.Runtime"))
+        .transform(
+            (builder, typeDescription, classLoader, module, protectionDomain) ->
+                builder
+                    .visit(
+                        Advice.to(NativeInterceptor.LoadLibraryAdvice.class)
+                            .on(named("loadLibrary").and(takesArgument(0, String.class))))
+                    .visit(
+                        Advice.to(NativeInterceptor.LoadAdvice.class)
+                            .on(named("load").and(takesArgument(0, String.class)))))
         .installOn(inst);
 
     LOG.debug("Instrumentation installed");

--- a/agent/src/main/java/org/jguard/agent/NativeInterceptor.java
+++ b/agent/src/main/java/org/jguard/agent/NativeInterceptor.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The jGuard Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.jguard.agent;
+
+import net.bytebuddy.asm.Advice;
+import org.jguard.bootstrap.BootstrapEnforcer;
+
+/**
+ * ByteBuddy advice for intercepting native library loading operations.
+ *
+ * <p>This class contains advice that is woven into JDK classes to enforce the {@code native.load}
+ * capability.
+ *
+ * <p>Instrumented methods:
+ *
+ * <ul>
+ *   <li>{@code System.loadLibrary(String)} - loads library from java.library.path
+ *   <li>{@code System.load(String)} - loads library from absolute path
+ *   <li>{@code Runtime.loadLibrary(String)} - delegates to System.loadLibrary
+ *   <li>{@code Runtime.load(String)} - delegates to System.load
+ * </ul>
+ */
+public final class NativeInterceptor {
+
+  private NativeInterceptor() {}
+
+  /**
+   * Advice for System.loadLibrary() and Runtime.loadLibrary().
+   *
+   * <p>Intercepts library loading by name to check if the caller is entitled to load native
+   * libraries.
+   */
+  public static class LoadLibraryAdvice {
+
+    private LoadLibraryAdvice() {}
+
+    @Advice.OnMethodEnter
+    public static void onEnter(@Advice.Argument(0) String libname) {
+      BootstrapEnforcer.onNativeLoad(libname);
+    }
+  }
+
+  /**
+   * Advice for System.load() and Runtime.load().
+   *
+   * <p>Intercepts library loading by absolute path to check if the caller is entitled to load
+   * native libraries.
+   */
+  public static class LoadAdvice {
+
+    private LoadAdvice() {}
+
+    @Advice.OnMethodEnter
+    public static void onEnter(@Advice.Argument(0) String filename) {
+      BootstrapEnforcer.onNativeLoad(filename);
+    }
+  }
+}

--- a/agent/src/main/java/org/jguard/agent/PolicyEnforcer.java
+++ b/agent/src/main/java/org/jguard/agent/PolicyEnforcer.java
@@ -49,6 +49,15 @@ public final class PolicyEnforcer {
     LOG.info("PolicyEnforcer initialized for module: {}", moduleName);
   }
 
+  /**
+   * Returns the module name this enforcer is configured for.
+   *
+   * @return the module name
+   */
+  public String getModuleName() {
+    return moduleName;
+  }
+
   // ========== SINGLE DISPATCH ENTRY POINT ==========
 
   /**

--- a/agent/src/main/java/org/jguard/agent/PolicyReloader.java
+++ b/agent/src/main/java/org/jguard/agent/PolicyReloader.java
@@ -1,0 +1,194 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The jGuard Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.jguard.agent;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.jguard.bootstrap.AgentConfig;
+import org.jguard.bootstrap.AgentLogger;
+import org.jguard.policy.model.PolicyDescriptor;
+import org.jguard.policy.serialization.BinaryPolicyReader;
+
+/**
+ * Watches for policy file changes and reloads the PolicyEnforcer when detected.
+ *
+ * <p>This enables administrators to update entitlements without restarting the JVM. The reloader
+ * polls the policy file at a configurable interval and atomically swaps the PolicyEnforcer when
+ * changes are detected.
+ *
+ * <p>Usage:
+ *
+ * <pre>{@code
+ * AtomicReference<PolicyEnforcer> enforcerRef = new AtomicReference<>(enforcer);
+ * PolicyReloader reloader = new PolicyReloader(policyPath, enforcerRef, config);
+ * reloader.start();
+ * }</pre>
+ *
+ * <p>The reloader uses a daemon thread and will not prevent JVM shutdown.
+ */
+public final class PolicyReloader {
+
+  private static final AgentLogger LOG = AgentLogger.getLogger(PolicyReloader.class);
+
+  /** Default polling interval in seconds. */
+  private static final long DEFAULT_POLL_INTERVAL_SECONDS = 5;
+
+  private final Path policyPath;
+  private final AtomicReference<PolicyEnforcer> enforcerRef;
+  private final AgentConfig config;
+  private final long pollIntervalSeconds;
+  private final ScheduledExecutorService scheduler;
+
+  private volatile FileTime lastModifiedTime;
+  private volatile boolean running;
+
+  /**
+   * Creates a new policy reloader.
+   *
+   * @param policyPath the path to the policy file to watch
+   * @param enforcerRef atomic reference to the current PolicyEnforcer
+   * @param config the agent configuration
+   */
+  public PolicyReloader(
+      Path policyPath, AtomicReference<PolicyEnforcer> enforcerRef, AgentConfig config) {
+    this(policyPath, enforcerRef, config, DEFAULT_POLL_INTERVAL_SECONDS);
+  }
+
+  /**
+   * Creates a new policy reloader with custom poll interval.
+   *
+   * @param policyPath the path to the policy file to watch
+   * @param enforcerRef atomic reference to the current PolicyEnforcer
+   * @param config the agent configuration
+   * @param pollIntervalSeconds interval between file checks in seconds
+   */
+  public PolicyReloader(
+      Path policyPath,
+      AtomicReference<PolicyEnforcer> enforcerRef,
+      AgentConfig config,
+      long pollIntervalSeconds) {
+    this.policyPath = policyPath;
+    this.enforcerRef = enforcerRef;
+    this.config = config;
+    this.pollIntervalSeconds = pollIntervalSeconds;
+    this.scheduler =
+        Executors.newSingleThreadScheduledExecutor(
+            r -> {
+              Thread t = new Thread(r, "jguard-policy-reloader");
+              t.setDaemon(true);
+              return t;
+            });
+
+    // Initialize last modified time
+    try {
+      this.lastModifiedTime = Files.getLastModifiedTime(policyPath);
+    } catch (IOException e) {
+      LOG.warn("Could not read initial policy file timestamp: {}", e.getMessage());
+      this.lastModifiedTime = null;
+    }
+  }
+
+  /**
+   * Starts the policy reloader.
+   *
+   * <p>The reloader will poll the policy file at the configured interval and reload the
+   * PolicyEnforcer when changes are detected.
+   */
+  public void start() {
+    if (running) {
+      LOG.warn("Policy reloader already running");
+      return;
+    }
+
+    running = true;
+    scheduler.scheduleAtFixedRate(
+        this::checkAndReload, pollIntervalSeconds, pollIntervalSeconds, TimeUnit.SECONDS);
+
+    LOG.info(
+        "Policy hot reload enabled: watching {} (interval={}s)", policyPath, pollIntervalSeconds);
+  }
+
+  /** Stops the policy reloader. */
+  public void stop() {
+    running = false;
+    scheduler.shutdown();
+    try {
+      if (!scheduler.awaitTermination(5, TimeUnit.SECONDS)) {
+        scheduler.shutdownNow();
+      }
+    } catch (InterruptedException e) {
+      scheduler.shutdownNow();
+      Thread.currentThread().interrupt();
+    }
+    LOG.info("Policy reloader stopped");
+  }
+
+  /** Checks if the policy file has changed and reloads if necessary. */
+  private void checkAndReload() {
+    try {
+      if (!Files.exists(policyPath)) {
+        LOG.warn("Policy file no longer exists: {}", policyPath);
+        return;
+      }
+
+      FileTime currentModifiedTime = Files.getLastModifiedTime(policyPath);
+
+      // Check if file has been modified
+      if (lastModifiedTime == null || currentModifiedTime.compareTo(lastModifiedTime) > 0) {
+        LOG.info("Policy file changed, reloading: {}", policyPath);
+        reload();
+        lastModifiedTime = currentModifiedTime;
+      }
+    } catch (Exception e) {
+      LOG.error("Error checking policy file for changes: {}", e.getMessage());
+    }
+  }
+
+  /** Reloads the policy from disk and swaps the PolicyEnforcer. */
+  private void reload() {
+    try {
+      // Read new policy
+      PolicyDescriptor newPolicy = BinaryPolicyReader.fromFile(policyPath);
+
+      // Create new enforcer
+      PolicyEnforcer newEnforcer = new PolicyEnforcer(newPolicy, config);
+
+      // Atomic swap
+      PolicyEnforcer oldEnforcer = enforcerRef.getAndSet(newEnforcer);
+
+      LOG.info(
+          "Policy reloaded successfully: module={}, entitlements={}",
+          newPolicy.moduleName(),
+          newPolicy.entitlements().size());
+
+      // Log if module name changed (unusual but possible)
+      if (oldEnforcer != null) {
+        String oldModule = oldEnforcer.getModuleName();
+        String newModule = newPolicy.moduleName();
+        if (!oldModule.equals(newModule)) {
+          LOG.warn("Policy module name changed: {} -> {}", oldModule, newModule);
+        }
+      }
+    } catch (IOException e) {
+      LOG.error("Failed to reload policy: {}", e.getMessage());
+    } catch (Exception e) {
+      LOG.error("Unexpected error reloading policy: {}", e.getMessage());
+    }
+  }
+
+  /** Returns true if the reloader is currently running. */
+  public boolean isRunning() {
+    return running;
+  }
+}

--- a/agent/src/main/java/org/jguard/agent/ThreadInterceptor.java
+++ b/agent/src/main/java/org/jguard/agent/ThreadInterceptor.java
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The jGuard Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.jguard.agent;
+
+import net.bytebuddy.asm.Advice;
+import org.jguard.bootstrap.BootstrapEnforcer;
+
+/**
+ * ByteBuddy advice for intercepting thread creation operations.
+ *
+ * <p>This class contains advice that is woven into JDK thread classes to enforce the {@code
+ * threads.create} capability.
+ */
+public final class ThreadInterceptor {
+
+  private ThreadInterceptor() {}
+
+  /**
+   * Advice for Thread.start() method.
+   *
+   * <p>Intercepts thread startup to check if the caller is entitled to create threads.
+   */
+  public static class ThreadStartAdvice {
+
+    private ThreadStartAdvice() {}
+
+    @Advice.OnMethodEnter
+    public static void onEnter(@Advice.This Thread thread) {
+      BootstrapEnforcer.onThreadCreate(thread);
+    }
+  }
+}

--- a/agent/src/test/java/org/jguard/agent/PolicyEnforcerTest.java
+++ b/agent/src/test/java/org/jguard/agent/PolicyEnforcerTest.java
@@ -407,6 +407,265 @@ class PolicyEnforcerTest {
     }
   }
 
+  @Nested
+  @DisplayName("SIMPLE category operations (threads.create, network.outbound)")
+  class SimpleOperationTest {
+
+    @Test
+    @DisplayName("allows threads.create when module is entitled")
+    void allowsThreadsCreate() {
+      Entitlement entitlement =
+          new Entitlement(SubjectPattern.module(), CapabilityGrant.of("threads.create"));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      assertThatCode(
+              () -> checkOperation(enforcer, caller("com.example.app"), Operation.THREAD_CREATE))
+          .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("denies threads.create when not entitled")
+    void deniesThreadsCreate() {
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of());
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      assertThatThrownBy(
+              () -> checkOperation(enforcer, caller("com.example.app"), Operation.THREAD_CREATE))
+          .isInstanceOf(SecurityException.class)
+          .hasMessageContaining("threads.create");
+    }
+
+    @Test
+    @DisplayName("allows network.outbound when entitled")
+    void allowsNetworkOutbound() {
+      Entitlement entitlement =
+          new Entitlement(SubjectPattern.module(), CapabilityGrant.of("network.outbound"));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      assertThatCode(
+              () -> checkOperation(enforcer, caller("com.example.app"), Operation.NET_CONNECT))
+          .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("denies network.outbound when not entitled")
+    void deniesNetworkOutbound() {
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of());
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      assertThatThrownBy(
+              () -> checkOperation(enforcer, caller("com.example.app"), Operation.NET_CONNECT))
+          .isInstanceOf(SecurityException.class)
+          .hasMessageContaining("network.outbound");
+    }
+
+    @Test
+    @DisplayName("respects package scope for threads.create")
+    void respectsPackageScopeForThreadsCreate() {
+      Entitlement entitlement =
+          new Entitlement(
+              SubjectPattern.exactPackage("com.example.app.worker"),
+              CapabilityGrant.of("threads.create"));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      // Entitled package allowed
+      assertThatCode(
+              () ->
+                  checkOperation(
+                      enforcer, caller("com.example.app.worker"), Operation.THREAD_CREATE))
+          .doesNotThrowAnyException();
+
+      // Other packages denied
+      assertThatThrownBy(
+              () -> checkOperation(enforcer, caller("com.example.app"), Operation.THREAD_CREATE))
+          .isInstanceOf(SecurityException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("TARGET_PATTERN category operations (native.load)")
+  class TargetPatternOperationTest {
+
+    @Test
+    @DisplayName("allows native.load when entitled with no pattern restriction")
+    void allowsNativeLoadAnyTarget() {
+      Entitlement entitlement =
+          new Entitlement(SubjectPattern.module(), CapabilityGrant.of("native.load"));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      // Any library should be allowed
+      assertThatCode(() -> checkNativeLoad(enforcer, caller("com.example.app"), "libcrypto"))
+          .doesNotThrowAnyException();
+      assertThatCode(() -> checkNativeLoad(enforcer, caller("com.example.app"), "libssl"))
+          .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("denies native.load when not entitled")
+    void deniesNativeLoad() {
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of());
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      assertThatThrownBy(() -> checkNativeLoad(enforcer, caller("com.example.app"), "libnative"))
+          .isInstanceOf(SecurityException.class)
+          .hasMessageContaining("native.load");
+    }
+
+    @Test
+    @DisplayName("allows native.load with exact pattern match")
+    void allowsNativeLoadExactPattern() {
+      Entitlement entitlement =
+          new Entitlement(
+              SubjectPattern.module(),
+              CapabilityGrant.of(
+                  "native.load", List.of(new CapabilityArgument.StringArg("libcrypto"))));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      // Exact match allowed
+      assertThatCode(() -> checkNativeLoad(enforcer, caller("com.example.app"), "libcrypto"))
+          .doesNotThrowAnyException();
+
+      // Non-matching denied
+      assertThatThrownBy(() -> checkNativeLoad(enforcer, caller("com.example.app"), "libssl"))
+          .isInstanceOf(SecurityException.class);
+    }
+
+    @Test
+    @DisplayName("allows native.load with wildcard pattern")
+    void allowsNativeLoadWildcardPattern() {
+      Entitlement entitlement =
+          new Entitlement(
+              SubjectPattern.module(),
+              CapabilityGrant.of(
+                  "native.load", List.of(new CapabilityArgument.StringArg("lib.*"))));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      // Direct children of lib. pattern allowed
+      assertThatCode(() -> checkNativeLoad(enforcer, caller("com.example.app"), "lib.crypto"))
+          .doesNotThrowAnyException();
+
+      // lib.sub.foo would NOT match (only one segment after lib.)
+      assertThatThrownBy(() -> checkNativeLoad(enforcer, caller("com.example.app"), "lib.sub.foo"))
+          .isInstanceOf(SecurityException.class);
+    }
+
+    @Test
+    @DisplayName("allows native.load with recursive pattern")
+    void allowsNativeLoadRecursivePattern() {
+      Entitlement entitlement =
+          new Entitlement(
+              SubjectPattern.module(),
+              CapabilityGrant.of(
+                  "native.load", List.of(new CapabilityArgument.StringArg("lib.**"))));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      // All descendants of lib allowed
+      assertThatCode(() -> checkNativeLoad(enforcer, caller("com.example.app"), "lib.crypto"))
+          .doesNotThrowAnyException();
+      assertThatCode(() -> checkNativeLoad(enforcer, caller("com.example.app"), "lib.sub.deep.foo"))
+          .doesNotThrowAnyException();
+
+      // Non-matching denied
+      assertThatThrownBy(() -> checkNativeLoad(enforcer, caller("com.example.app"), "other.lib"))
+          .isInstanceOf(SecurityException.class);
+    }
+
+    @Test
+    @DisplayName("respects package scope for native.load")
+    void respectsPackageScopeForNativeLoad() {
+      Entitlement entitlement =
+          new Entitlement(
+              SubjectPattern.exactPackage("com.example.app.native"),
+              CapabilityGrant.of("native.load"));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      // Entitled package allowed
+      assertThatCode(() -> checkNativeLoad(enforcer, caller("com.example.app.native"), "libfoo"))
+          .doesNotThrowAnyException();
+
+      // Other packages denied
+      assertThatThrownBy(() -> checkNativeLoad(enforcer, caller("com.example.app"), "libfoo"))
+          .isInstanceOf(SecurityException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("PORT category operations (network.listen)")
+  class PortOperationTest {
+
+    @Test
+    @DisplayName("allows network.listen when entitled with no port restriction")
+    void allowsNetworkListenAnyPort() {
+      Entitlement entitlement =
+          new Entitlement(SubjectPattern.module(), CapabilityGrant.of("network.listen"));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      // Any port should be allowed
+      assertThatCode(() -> checkNetworkListen(enforcer, caller("com.example.app"), 8080))
+          .doesNotThrowAnyException();
+      assertThatCode(() -> checkNetworkListen(enforcer, caller("com.example.app"), 443))
+          .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("denies network.listen when not entitled")
+    void deniesNetworkListen() {
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of());
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      assertThatThrownBy(() -> checkNetworkListen(enforcer, caller("com.example.app"), 8080))
+          .isInstanceOf(SecurityException.class)
+          .hasMessageContaining("network.listen");
+    }
+
+    @Test
+    @DisplayName("allows network.listen with specific port restriction")
+    void allowsNetworkListenSpecificPort() {
+      Entitlement entitlement =
+          new Entitlement(
+              SubjectPattern.module(),
+              CapabilityGrant.of(
+                  "network.listen", List.of(new CapabilityArgument.IntegerArg(8080))));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      // Exact port match allowed
+      assertThatCode(() -> checkNetworkListen(enforcer, caller("com.example.app"), 8080))
+          .doesNotThrowAnyException();
+
+      // Ephemeral port (0) allowed with any entitlement
+      assertThatCode(() -> checkNetworkListen(enforcer, caller("com.example.app"), 0))
+          .doesNotThrowAnyException();
+
+      // Different port denied
+      assertThatThrownBy(() -> checkNetworkListen(enforcer, caller("com.example.app"), 9090))
+          .isInstanceOf(SecurityException.class);
+    }
+  }
+
   // ===== Helper methods =====
 
   private Entitlement fsReadEntitlement(String root, String glob) {
@@ -449,6 +708,31 @@ class PolicyEnforcerTest {
   /** Helper to call check() and throw if denied, for test readability. */
   private static void checkFsRead(PolicyEnforcer enforcer, CallerContext caller, Path path) {
     SecurityException denial = enforcer.check(caller, Operation.FS_READ, path, 0);
+    if (denial != null) {
+      throw denial;
+    }
+  }
+
+  /** Helper for SIMPLE category operations (threads.create, network.outbound). */
+  private static void checkOperation(PolicyEnforcer enforcer, CallerContext caller, Operation op) {
+    SecurityException denial = enforcer.check(caller, op, "test", 0);
+    if (denial != null) {
+      throw denial;
+    }
+  }
+
+  /** Helper for native.load operations. */
+  private static void checkNativeLoad(
+      PolicyEnforcer enforcer, CallerContext caller, String libraryName) {
+    SecurityException denial = enforcer.check(caller, Operation.NATIVE_LOAD, libraryName, 0);
+    if (denial != null) {
+      throw denial;
+    }
+  }
+
+  /** Helper for network.listen operations. */
+  private static void checkNetworkListen(PolicyEnforcer enforcer, CallerContext caller, int port) {
+    SecurityException denial = enforcer.check(caller, Operation.NET_LISTEN, null, port);
     if (denial != null) {
       throw denial;
     }

--- a/agent/src/test/java/org/jguard/agent/PolicyReloaderTest.java
+++ b/agent/src/test/java/org/jguard/agent/PolicyReloaderTest.java
@@ -1,0 +1,215 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The jGuard Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.jguard.agent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.jguard.bootstrap.AgentConfig;
+import org.jguard.bootstrap.EnforcementMode;
+import org.jguard.policy.model.CapabilityGrant;
+import org.jguard.policy.model.Entitlement;
+import org.jguard.policy.model.PolicyDescriptor;
+import org.jguard.policy.model.SubjectPattern;
+import org.jguard.policy.serialization.BinaryPolicyWriter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Tests for {@link PolicyReloader}. */
+class PolicyReloaderTest {
+
+  @TempDir Path tempDir;
+
+  private Path policyPath;
+  private AtomicReference<PolicyEnforcer> enforcerRef;
+  private PolicyReloader reloader;
+  private AgentConfig config;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    policyPath = tempDir.resolve("policy.bin");
+
+    // Create initial policy
+    PolicyDescriptor initialPolicy = createPolicy("com.example.app", "network.outbound");
+    writePolicyFile(policyPath, initialPolicy);
+
+    // Create config
+    config = new AgentConfig.Builder().policyPath(policyPath).mode(EnforcementMode.STRICT).build();
+
+    // Create initial enforcer
+    PolicyEnforcer initialEnforcer = new PolicyEnforcer(initialPolicy, config);
+    enforcerRef = new AtomicReference<>(initialEnforcer);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (reloader != null && reloader.isRunning()) {
+      reloader.stop();
+    }
+  }
+
+  @Test
+  @DisplayName("starts and stops without error")
+  void startsAndStops() {
+    reloader = new PolicyReloader(policyPath, enforcerRef, config, 1);
+
+    reloader.start();
+    assertThat(reloader.isRunning()).isTrue();
+
+    reloader.stop();
+    assertThat(reloader.isRunning()).isFalse();
+  }
+
+  @Test
+  @DisplayName("does not restart if already running")
+  void doesNotRestartIfRunning() {
+    reloader = new PolicyReloader(policyPath, enforcerRef, config, 1);
+
+    reloader.start();
+    assertThat(reloader.isRunning()).isTrue();
+
+    // Calling start again should be a no-op
+    reloader.start();
+    assertThat(reloader.isRunning()).isTrue();
+  }
+
+  @Test
+  @DisplayName("reloads policy when file changes")
+  void reloadsPolicyWhenFileChanges() throws Exception {
+    // Use 1 second poll interval for test speed
+    reloader = new PolicyReloader(policyPath, enforcerRef, config, 1);
+    reloader.start();
+
+    // Get initial enforcer reference
+    PolicyEnforcer initialEnforcer = enforcerRef.get();
+    assertThat(initialEnforcer).isNotNull();
+
+    // Wait a moment to ensure we're past initial file check
+    Thread.sleep(100);
+
+    // Update the policy file
+    PolicyDescriptor newPolicy =
+        createPolicy("com.example.app", "network.outbound", "threads.create");
+    writePolicyFile(policyPath, newPolicy);
+
+    // Wait for reload (poll interval + some buffer)
+    Thread.sleep(2000);
+
+    // Verify enforcer was swapped
+    PolicyEnforcer newEnforcer = enforcerRef.get();
+    assertThat(newEnforcer).isNotNull();
+    assertThat(newEnforcer).isNotSameAs(initialEnforcer);
+  }
+
+  @Test
+  @DisplayName("does not reload if file unchanged")
+  void doesNotReloadIfUnchanged() throws Exception {
+    reloader = new PolicyReloader(policyPath, enforcerRef, config, 1);
+    reloader.start();
+
+    // Get initial enforcer
+    PolicyEnforcer initialEnforcer = enforcerRef.get();
+
+    // Wait for a few poll cycles
+    Thread.sleep(3000);
+
+    // Enforcer should be the same instance
+    assertThat(enforcerRef.get()).isSameAs(initialEnforcer);
+  }
+
+  @Test
+  @DisplayName("handles missing policy file gracefully")
+  void handlesMissingPolicyFile() throws Exception {
+    reloader = new PolicyReloader(policyPath, enforcerRef, config, 1);
+    reloader.start();
+
+    PolicyEnforcer initialEnforcer = enforcerRef.get();
+
+    // Delete the policy file
+    Files.delete(policyPath);
+
+    // Wait for poll cycle
+    Thread.sleep(2000);
+
+    // Enforcer should remain unchanged
+    assertThat(enforcerRef.get()).isSameAs(initialEnforcer);
+    assertThat(reloader.isRunning()).isTrue();
+  }
+
+  @Test
+  @DisplayName("handles corrupted policy file gracefully")
+  void handlesCorruptedPolicyFile() throws Exception {
+    reloader = new PolicyReloader(policyPath, enforcerRef, config, 1);
+    reloader.start();
+
+    PolicyEnforcer initialEnforcer = enforcerRef.get();
+
+    // Wait a moment
+    Thread.sleep(100);
+
+    // Write garbage to the policy file
+    Files.writeString(policyPath, "not a valid policy file");
+
+    // Wait for poll cycle
+    Thread.sleep(2000);
+
+    // Enforcer should remain unchanged (reload failed)
+    assertThat(enforcerRef.get()).isSameAs(initialEnforcer);
+    assertThat(reloader.isRunning()).isTrue();
+  }
+
+  @Test
+  @DisplayName("uses configured poll interval")
+  void usesConfiguredPollInterval() throws Exception {
+    // Use 3 second poll interval
+    reloader = new PolicyReloader(policyPath, enforcerRef, config, 3);
+    reloader.start();
+
+    PolicyEnforcer initialEnforcer = enforcerRef.get();
+
+    // Update file immediately
+    PolicyDescriptor newPolicy = createPolicy("com.example.app", "threads.create");
+    writePolicyFile(policyPath, newPolicy);
+
+    // Wait 1.5 seconds - less than poll interval
+    Thread.sleep(1500);
+
+    // Should not have reloaded yet
+    assertThat(enforcerRef.get()).isSameAs(initialEnforcer);
+
+    // Wait for remaining poll time + buffer
+    Thread.sleep(2500);
+
+    // Now should have reloaded
+    assertThat(enforcerRef.get()).isNotSameAs(initialEnforcer);
+  }
+
+  // ===== Helper methods =====
+
+  private PolicyDescriptor createPolicy(String moduleName, String... capabilities) {
+    List<Entitlement> entitlements =
+        java.util.Arrays.stream(capabilities)
+            .map(cap -> new Entitlement(SubjectPattern.module(), CapabilityGrant.of(cap)))
+            .toList();
+    return PolicyDescriptor.create(moduleName, entitlements);
+  }
+
+  private void writePolicyFile(Path path, PolicyDescriptor policy) throws IOException {
+    try (OutputStream out = Files.newOutputStream(path)) {
+      BinaryPolicyWriter.write(policy, out);
+    }
+  }
+}

--- a/cli/README.md
+++ b/cli/README.md
@@ -176,7 +176,7 @@ The compiler validates that only known capabilities are used:
 | `fs.write` | `(root, glob)` | Write files matching glob under root |
 | `network.outbound` | none | Make outbound network connections |
 | `network.listen` | `(port)` | Listen on a port |
-| `threads.spawn` | none | Spawn new threads |
+| `threads.create` | none | Spawn new threads |
 | `native.load` | none | Load native libraries |
 
 ### See Also

--- a/cli/src/test/resources/valid-policy.jguard
+++ b/cli/src/test/resources/valid-policy.jguard
@@ -8,5 +8,5 @@
 security module com.example.app {
     entitle module to fs.read("/data", "*.json");
     entitle com.example.app.net to network.outbound;
-    entitle com.example.app.worker.. to threads.spawn;
+    entitle com.example.app.worker.. to threads.create;
 }

--- a/docs/spec/jguard-policy-descriptor.md
+++ b/docs/spec/jguard-policy-descriptor.md
@@ -220,14 +220,33 @@ Each capability has a fixed signature that determines:
 * whether arguments are required
 * the type and meaning of each argument
 
-For example:
+The following capabilities are defined in jGuard version 1:
 
-| Capability         | Signature      |
-| ------------------ | -------------- |
-| `network.outbound` | no arguments   |
-| `fs.read`          | `(root, glob)` |
+| Capability         | Signature                | Description                              |
+| ------------------ | ------------------------ | ---------------------------------------- |
+| `fs.read`          | `(root, glob)`           | Read files matching glob under root      |
+| `fs.write`         | `(root, glob)`           | Write files matching glob under root     |
+| `network.outbound` | (no arguments)           | Open outbound network connections        |
+| `network.listen`   | `(port?)`                | Bind server sockets (optional port)      |
+| `threads.create`   | (no arguments)           | Create new threads                       |
+| `native.load`      | `(pattern?)`             | Load native libraries (optional pattern) |
 
-Implementations MUST reject entitlement declarations whose arguments do not conform to the capability’s signature.
+#### Argument details
+
+**`fs.read(root, glob)` / `fs.write(root, glob)`**
+
+* `root` — base directory path (string)
+* `glob` — glob pattern for matching files (string, e.g., `"**/*"`, `"*.txt"`)
+
+**`network.listen(port?)`**
+
+* `port` — optional port number (integer); if omitted, allows binding to any port
+
+**`native.load(pattern?)`**
+
+* `pattern` — optional library name pattern (string); if omitted, allows loading any library
+
+Implementations MUST reject entitlement declarations whose arguments do not conform to the capability's signature.
 
 ### 6.2 Accumulation of entitlements
 

--- a/gradle-plugin/README.md
+++ b/gradle-plugin/README.md
@@ -26,13 +26,12 @@ includeBuild("../jguard")
 1. Create a policy file at `src/main/java/module-info.jguard`:
 
 ```
-module com.example.myapp {
-    // Grant filesystem read access to source directories
-    grant {
-        package com.example.myapp {
-            fs.read("src", "**/*");
-        }
-    }
+security module com.example.myapp {
+    // Grant filesystem read access to the entire module
+    entitle module to fs.read("src", "**/*");
+
+    // Grant network access to specific packages
+    entitle com.example.myapp.http.. to network.outbound;
 }
 ```
 

--- a/policy-java/README.md
+++ b/policy-java/README.md
@@ -22,7 +22,7 @@ import static org.jguard.policy.java.Subjects.*;
 PolicyDescriptor policy = JGuardPolicy.forModule("com.example.app")
     .grant(module(), fsRead("/data", "*.json"))
     .grant(pkg("com.example.app.net"), networkOutbound())
-    .grant(pkgRecursive("com.example.app.worker"), threadsSpawn())
+    .grant(pkgRecursive("com.example.app.worker"), threadsCreate())
     .build();
 ```
 
@@ -33,7 +33,7 @@ This is equivalent to:
 security module com.example.app {
     entitle module to fs.read("/data", "*.json");
     entitle com.example.app.net to network.outbound;
-    entitle com.example.app.worker.. to threads.spawn;
+    entitle com.example.app.worker.. to threads.create;
 }
 ```
 
@@ -72,7 +72,7 @@ Factory methods for defining what actions are permitted.
 | `fsWrite(root, glob)` | `fs.write("/path", "*.ext")` | Write files matching glob under root |
 | `networkOutbound()` | `network.outbound` | Make outbound network connections |
 | `networkListen(port)` | `network.listen(8080)` | Listen on a specific port |
-| `threadsSpawn()` | `threads.spawn` | Create new threads |
+| `threadsCreate()` | `threads.create` | Create new threads |
 | `nativeLoad()` | `native.load` | Load native libraries |
 
 ## Examples
@@ -104,7 +104,7 @@ grant(pkgChildren("com.example.app.server"), networkListen(8080));
 
 ```java
 // Allow worker packages to spawn threads
-grant(pkgRecursive("com.example.app.worker"), threadsSpawn());
+grant(pkgRecursive("com.example.app.worker"), threadsCreate());
 ```
 
 ### Native Libraries
@@ -138,7 +138,7 @@ public class PolicyGenerator {
             .grant(pkgChildren("com.example.app.server"), networkListen(8080))
 
             // Thread spawning for worker hierarchy
-            .grant(pkgRecursive("com.example.app.worker"), threadsSpawn())
+            .grant(pkgRecursive("com.example.app.worker"), threadsCreate())
 
             // Native library loading
             .grant(pkg("com.example.app.jni"), nativeLoad())

--- a/policy-java/src/main/java/org/jguard/policy/java/Capabilities.java
+++ b/policy-java/src/main/java/org/jguard/policy/java/Capabilities.java
@@ -92,12 +92,12 @@ public final class Capabilities {
   // ===== Thread Capabilities =====
 
   /**
-   * Creates a thread spawn capability.
+   * Creates a thread creation capability.
    *
    * @return the capability grant
    */
-  public static CapabilityGrant threadsSpawn() {
-    return CapabilityGrant.of("threads.spawn");
+  public static CapabilityGrant threadsCreate() {
+    return CapabilityGrant.of("threads.create");
   }
 
   // ===== Native Capabilities =====

--- a/policy-java/src/main/java/org/jguard/policy/java/JGuardPolicy.java
+++ b/policy-java/src/main/java/org/jguard/policy/java/JGuardPolicy.java
@@ -29,7 +29,7 @@ import org.jguard.policy.model.SubjectPattern;
  * PolicyDescriptor policy = JGuardPolicy.forModule("com.example.app")
  *     .grant(module(), fsRead("/data", "*.json"))
  *     .grant(pkg("com.example.app.net"), networkOutbound())
- *     .grant(pkgRecursive("com.example.app.worker"), threadsSpawn())
+ *     .grant(pkgRecursive("com.example.app.worker"), threadsCreate())
  *     .build();
  * }</pre>
  *
@@ -41,7 +41,7 @@ import org.jguard.policy.model.SubjectPattern;
  * security module com.example.app {
  *     entitle module to fs.read("/data", "*.json");
  *     entitle com.example.app.net to network.outbound;
- *     entitle com.example.app.worker.. to threads.spawn;
+ *     entitle com.example.app.worker.. to threads.create;
  * }
  * }</pre>
  *

--- a/policy-java/src/test/java/org/jguard/policy/java/CapabilitiesTest.java
+++ b/policy-java/src/test/java/org/jguard/policy/java/CapabilitiesTest.java
@@ -168,15 +168,15 @@ class CapabilitiesTest {
   }
 
   @Nested
-  @DisplayName("threads.spawn")
+  @DisplayName("threads.create")
   class ThreadsSpawnTest {
 
     @Test
-    @DisplayName("creates threads.spawn capability without arguments")
+    @DisplayName("creates threads.create capability without arguments")
     void createsThreadsSpawnCapability() {
-      CapabilityGrant capability = threadsSpawn();
+      CapabilityGrant capability = threadsCreate();
 
-      assertThat(capability.name()).isEqualTo("threads.spawn");
+      assertThat(capability.name()).isEqualTo("threads.create");
       assertThat(capability.hasArguments()).isFalse();
     }
   }
@@ -203,7 +203,7 @@ class CapabilitiesTest {
     @DisplayName("capabilities produce correct canonical strings")
     void correctCanonicalStrings() {
       assertThat(networkOutbound().toCanonicalString()).isEqualTo("network.outbound");
-      assertThat(threadsSpawn().toCanonicalString()).isEqualTo("threads.spawn");
+      assertThat(threadsCreate().toCanonicalString()).isEqualTo("threads.create");
       assertThat(nativeLoad().toCanonicalString()).isEqualTo("native.load");
       assertThat(networkListen(8080).toCanonicalString()).isEqualTo("network.listen(8080)");
       assertThat(fsRead("/data", "*.json").toCanonicalString())

--- a/policy-java/src/test/java/org/jguard/policy/java/JGuardPolicyTest.java
+++ b/policy-java/src/test/java/org/jguard/policy/java/JGuardPolicyTest.java
@@ -78,7 +78,7 @@ class JGuardPolicyTest {
           JGuardPolicy.forModule("com.example.app")
               .grant(module(), networkOutbound())
               .grant(pkg("com.example.net"), fsRead("/tmp", "*"))
-              .grant(pkgRecursive("com.example.worker"), threadsSpawn());
+              .grant(pkgRecursive("com.example.worker"), threadsCreate());
 
       assertThat(builder.entitlementCount()).isEqualTo(3);
     }

--- a/policy-java/src/test/java/org/jguard/policy/java/ParityTest.java
+++ b/policy-java/src/test/java/org/jguard/policy/java/ParityTest.java
@@ -110,13 +110,13 @@ class ParityTest {
       String jguardSource =
           """
           security module com.example.app {
-              entitle com.example.worker.. to threads.spawn;
+              entitle com.example.worker.. to threads.create;
           }
           """;
 
       PolicyDescriptor javaPolicy =
           JGuardPolicy.forModule("com.example.app")
-              .grant(pkgRecursive("com.example.worker"), threadsSpawn())
+              .grant(pkgRecursive("com.example.worker"), threadsCreate())
               .build();
 
       assertBinaryParity(jguardSource, javaPolicy);
@@ -130,7 +130,7 @@ class ParityTest {
           security module com.example.app {
               entitle module to fs.read("/data", "*.json");
               entitle com.example.app.net to network.outbound;
-              entitle com.example.app.worker.. to threads.spawn;
+              entitle com.example.app.worker.. to threads.create;
               entitle com.example.app.jni to native.load;
           }
           """;
@@ -139,7 +139,7 @@ class ParityTest {
           JGuardPolicy.forModule("com.example.app")
               .grant(module(), fsRead("/data", "*.json"))
               .grant(pkg("com.example.app.net"), networkOutbound())
-              .grant(pkgRecursive("com.example.app.worker"), threadsSpawn())
+              .grant(pkgRecursive("com.example.app.worker"), threadsCreate())
               .grant(pkg("com.example.app.jni"), nativeLoad())
               .build();
 
@@ -153,7 +153,7 @@ class ParityTest {
       String jguardSource =
           """
           security module com.example.app {
-              entitle com.example.app.worker.. to threads.spawn;
+              entitle com.example.app.worker.. to threads.create;
               entitle module to network.outbound;
               entitle com.example.app.net to fs.read("/tmp", "*");
           }
@@ -164,7 +164,7 @@ class ParityTest {
           JGuardPolicy.forModule("com.example.app")
               .grant(pkg("com.example.app.net"), fsRead("/tmp", "*"))
               .grant(module(), networkOutbound())
-              .grant(pkgRecursive("com.example.app.worker"), threadsSpawn())
+              .grant(pkgRecursive("com.example.app.worker"), threadsCreate())
               .build();
 
       assertBinaryParity(jguardSource, javaPolicy);
@@ -185,7 +185,7 @@ class ParityTest {
               entitle module to fs.write("/tmp", "*.log");
               entitle com.example.app.net to network.outbound;
               entitle com.example.app.server.* to network.listen(8080);
-              entitle com.example.app.worker.. to threads.spawn;
+              entitle com.example.app.worker.. to threads.create;
               entitle com.example.app.jni to native.load;
           }
           """;
@@ -196,7 +196,7 @@ class ParityTest {
               .grant(module(), fsWrite("/tmp", "*.log"))
               .grant(pkg("com.example.app.net"), networkOutbound())
               .grant(pkgChildren("com.example.app.server"), networkListen(8080))
-              .grant(pkgRecursive("com.example.app.worker"), threadsSpawn())
+              .grant(pkgRecursive("com.example.app.worker"), threadsCreate())
               .grant(pkg("com.example.app.jni"), nativeLoad())
               .build();
 

--- a/policy/README.md
+++ b/policy/README.md
@@ -57,7 +57,7 @@ security module com.example.myapp {
     entitle com.example.myapp.handlers.* to network.listen(8080);
 
     // Grant recursively to package and all descendants
-    entitle com.example.myapp.worker.. to threads.spawn;
+    entitle com.example.myapp.worker.. to threads.create;
 
 }
 ```
@@ -78,9 +78,9 @@ security module com.example.myapp {
 | `fs.read(root, glob)` | 2 strings | Read files under `root` matching `glob` |
 | `fs.write(root, glob)` | 2 strings | Write files under `root` matching `glob` |
 | `network.outbound` | none | Make outbound network connections |
-| `network.listen(port)` | 1 integer | Listen on a specific port |
-| `threads.spawn` | none | Create new threads |
-| `native.load` | none | Load native libraries |
+| `network.listen(port?)` | 0-1 integer | Listen on a specific port (optional) |
+| `threads.create` | none | Create new threads |
+| `native.load(pattern?)` | 0-1 string | Load native libraries (optional pattern) |
 
 ### Lexical Elements
 

--- a/policy/src/main/java/org/jguard/policy/validation/PolicyValidator.java
+++ b/policy/src/main/java/org/jguard/policy/validation/PolicyValidator.java
@@ -39,15 +39,15 @@ public final class PolicyValidator {
   private static final Pattern JAVA_IDENTIFIER = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_]*$");
 
   // Known capabilities and their expected argument counts
-  // For v0.1.0: fs.read(root, glob) and network.outbound
+  // For v0.1.0: fs.read/write, network.outbound/listen, threads.create, native.load
   private static final Map<String, CapabilitySignature> KNOWN_CAPABILITIES =
       Map.of(
           "fs.read", new CapabilitySignature(2, 2, List.of(ArgType.STRING, ArgType.STRING)),
           "fs.write", new CapabilitySignature(2, 2, List.of(ArgType.STRING, ArgType.STRING)),
           "network.outbound", new CapabilitySignature(0, 0, List.of()),
           "network.listen", new CapabilitySignature(0, 1, List.of(ArgType.INTEGER)),
-          "threads.spawn", new CapabilitySignature(0, 0, List.of()),
-          "native.load", new CapabilitySignature(0, 0, List.of()));
+          "threads.create", new CapabilitySignature(0, 0, List.of()),
+          "native.load", new CapabilitySignature(0, 1, List.of(ArgType.STRING)));
 
   private final String sourcePath;
   private final List<CompilationResult.Diagnostic> diagnostics = new ArrayList<>();

--- a/policy/src/test/java/org/jguard/policy/compiler/DeterminismTest.java
+++ b/policy/src/test/java/org/jguard/policy/compiler/DeterminismTest.java
@@ -75,14 +75,14 @@ class DeterminismTest {
             security module com.example.app {
                 entitle module to fs.read("/data", "*.json");
                 entitle com.example.app.http to network.outbound;
-                entitle com.example.app.worker.. to threads.spawn;
+                entitle com.example.app.worker.. to threads.create;
             }
             """;
 
     String source2 =
         """
             security module com.example.app {
-                entitle com.example.app.worker.. to threads.spawn;
+                entitle com.example.app.worker.. to threads.create;
                 entitle module to fs.read("/data", "*.json");
                 entitle com.example.app.http to network.outbound;
             }

--- a/policy/src/test/java/org/jguard/policy/compiler/ValidationTest.java
+++ b/policy/src/test/java/org/jguard/policy/compiler/ValidationTest.java
@@ -97,7 +97,7 @@ class ValidationTest {
                 entitle module to fs.write("/tmp", "*.log");
                 entitle module to network.outbound;
                 entitle module to network.listen(8080);
-                entitle module to threads.spawn;
+                entitle module to threads.create;
                 entitle module to native.load;
             }
             """;
@@ -116,7 +116,7 @@ class ValidationTest {
                 entitle module to network.outbound;
                 entitle com.example.app.http to network.outbound;
                 entitle com.example.app.handlers.* to network.outbound;
-                entitle com.example.app.worker.. to threads.spawn;
+                entitle com.example.app.worker.. to threads.create;
             }
             """;
 

--- a/policy/src/test/java/org/jguard/policy/parser/ParserTest.java
+++ b/policy/src/test/java/org/jguard/policy/parser/ParserTest.java
@@ -83,7 +83,7 @@ class ParserTest {
   @Test
   void parsesRecursiveSubject() {
     PolicyFile ast =
-        parse("security module app { entitle com.example.worker.. to threads.spawn; }");
+        parse("security module app { entitle com.example.worker.. to threads.create; }");
     assertThat(ast.entitlements()).hasSize(1);
 
     Subject.Package pkg = (Subject.Package) ast.entitlements().get(0).subject();
@@ -164,7 +164,7 @@ class ParserTest {
         security module app {
             entitle module to fs.read("/data", "*");
             entitle com.example.net to network.outbound;
-            entitle com.example.worker.. to threads.spawn;
+            entitle com.example.worker.. to threads.create;
         }
         """;
 
@@ -183,7 +183,7 @@ class ParserTest {
     // Third entitlement
     Subject.Package pkg3 = (Subject.Package) ast.entitlements().get(2).subject();
     assertThat(pkg3.pattern().matchType()).isEqualTo(PackagePattern.MatchType.RECURSIVE);
-    assertThat(ast.entitlements().get(2).capability().name()).isEqualTo("threads.spawn");
+    assertThat(ast.entitlements().get(2).capability().name()).isEqualTo("threads.create");
   }
 
   // ===== Source Location Tracking =====

--- a/policy/src/test/java/org/jguard/policy/serialization/SerializationTest.java
+++ b/policy/src/test/java/org/jguard/policy/serialization/SerializationTest.java
@@ -195,7 +195,7 @@ class SerializationTest {
           new Entitlement(SubjectPattern.module(), CapabilityGrant.of("network.outbound"));
       Entitlement e2 =
           new Entitlement(
-              SubjectPattern.exactPackage("com.example"), CapabilityGrant.of("threads.spawn"));
+              SubjectPattern.exactPackage("com.example"), CapabilityGrant.of("threads.create"));
       PolicyDescriptor policy = PolicyDescriptor.create("app", List.of(e1, e2));
 
       byte[] bytes1 = BinaryPolicyWriter.toBytes(policy);
@@ -210,7 +210,7 @@ class SerializationTest {
           new Entitlement(SubjectPattern.module(), CapabilityGrant.of("network.outbound"));
       Entitlement e2 =
           new Entitlement(
-              SubjectPattern.exactPackage("com.example"), CapabilityGrant.of("threads.spawn"));
+              SubjectPattern.exactPackage("com.example"), CapabilityGrant.of("threads.create"));
       Entitlement e3 =
           new Entitlement(
               SubjectPattern.recursive("com.worker"), CapabilityGrant.of("native.load"));
@@ -443,7 +443,7 @@ class SerializationTest {
           new Entitlement(SubjectPattern.module(), CapabilityGrant.of("network.outbound"));
       Entitlement e2 =
           new Entitlement(
-              SubjectPattern.exactPackage("com.example"), CapabilityGrant.of("threads.spawn"));
+              SubjectPattern.exactPackage("com.example"), CapabilityGrant.of("threads.create"));
       PolicyDescriptor policy = PolicyDescriptor.create("app", List.of(e1, e2));
 
       String json1 = JsonPolicyWriter.toJson(policy);
@@ -467,7 +467,7 @@ class SerializationTest {
           new Entitlement(SubjectPattern.module(), CapabilityGrant.of("network.outbound"));
       Entitlement e2 =
           new Entitlement(
-              SubjectPattern.exactPackage("com.example"), CapabilityGrant.of("threads.spawn"));
+              SubjectPattern.exactPackage("com.example"), CapabilityGrant.of("threads.create"));
       Entitlement e3 =
           new Entitlement(
               SubjectPattern.recursive("com.worker"), CapabilityGrant.of("native.load"));
@@ -538,7 +538,7 @@ class SerializationTest {
           new Entitlement(SubjectPattern.module(), CapabilityGrant.of("network.outbound"));
       Entitlement ePkgA =
           new Entitlement(
-              SubjectPattern.exactPackage("a.pkg"), CapabilityGrant.of("threads.spawn"));
+              SubjectPattern.exactPackage("a.pkg"), CapabilityGrant.of("threads.create"));
       Entitlement ePkgZ =
           new Entitlement(SubjectPattern.exactPackage("z.pkg"), CapabilityGrant.of("native.load"));
 
@@ -616,7 +616,7 @@ class SerializationTest {
     void readsRecursiveSubject() throws IOException {
       Entitlement entitlement =
           new Entitlement(
-              SubjectPattern.recursive("com.worker"), CapabilityGrant.of("threads.spawn"));
+              SubjectPattern.recursive("com.worker"), CapabilityGrant.of("threads.create"));
       PolicyDescriptor original = PolicyDescriptor.create("app", List.of(entitlement));
 
       byte[] bytes = BinaryPolicyWriter.toBytes(original);
@@ -671,7 +671,7 @@ class SerializationTest {
           new Entitlement(SubjectPattern.module(), CapabilityGrant.of("network.outbound"));
       Entitlement e2 =
           new Entitlement(
-              SubjectPattern.exactPackage("com.example"), CapabilityGrant.of("threads.spawn"));
+              SubjectPattern.exactPackage("com.example"), CapabilityGrant.of("threads.create"));
       Entitlement e3 =
           new Entitlement(
               SubjectPattern.recursive("com.worker"), CapabilityGrant.of("native.load"));
@@ -698,7 +698,7 @@ class SerializationTest {
       Entitlement e2 = new Entitlement(SubjectPattern.exactPackage("com.example.net"), listen);
       Entitlement e3 =
           new Entitlement(
-              SubjectPattern.recursive("com.worker"), CapabilityGrant.of("threads.spawn"));
+              SubjectPattern.recursive("com.worker"), CapabilityGrant.of("threads.create"));
       PolicyDescriptor original = PolicyDescriptor.create("com.example.app", List.of(e1, e2, e3));
 
       byte[] bytes = BinaryPolicyWriter.toBytes(original);
@@ -748,7 +748,7 @@ class SerializationTest {
       Entitlement e2 = new Entitlement(SubjectPattern.exactPackage("com.example.net"), listen);
       Entitlement e3 =
           new Entitlement(
-              SubjectPattern.recursive("com.worker"), CapabilityGrant.of("threads.spawn"));
+              SubjectPattern.recursive("com.worker"), CapabilityGrant.of("threads.create"));
 
       PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(e1, e2, e3));
 

--- a/policy/src/test/java/org/jguard/policy/validation/PolicyValidatorTest.java
+++ b/policy/src/test/java/org/jguard/policy/validation/PolicyValidatorTest.java
@@ -165,7 +165,7 @@ class PolicyValidatorTest {
 
     @Test
     void acceptsThreadsSpawn() {
-      EntitlementDeclaration entitlement = moduleEntitlement("threads.spawn");
+      EntitlementDeclaration entitlement = moduleEntitlement("threads.create");
       PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
 
       PolicyValidator.ValidationResult result = validate(ast);

--- a/samples/sandbox-demo/README.md
+++ b/samples/sandbox-demo/README.md
@@ -37,13 +37,13 @@ security module com.example.myapp {
     entitle com.example.myapp.http to network.outbound;
 
     // Grant thread spawning to worker packages
-    entitle com.example.myapp.workers.. to threads.spawn;
+    entitle com.example.myapp.workers.. to threads.create;
 
 }
 ```
 
 The policy file declares:
-- **What** capabilities are granted (`fs.read`, `network.outbound`, `threads.spawn`)
+- **What** capabilities are granted (`fs.read`, `network.outbound`, `threads.create`)
 - **Who** gets them (`module` for everything, or specific packages)
 
 ### 3. Write Your Java Code
@@ -88,9 +88,9 @@ jGuard enforces your policy transparently—if the code is entitled, it runs; if
 | `fs.read(root, glob)` | Read files matching glob under root |
 | `fs.write(root, glob)` | Write files matching glob under root |
 | `network.outbound` | Make outbound network connections |
-| `network.listen(port)` | Listen on a port |
-| `threads.spawn` | Create threads |
-| `native.load` | Load native libraries |
+| `network.listen(port?)` | Listen on a port (optional port arg) |
+| `threads.create` | Create threads |
+| `native.load(pattern?)` | Load native libraries (optional pattern) |
 
 ## What Gets Built
 
@@ -163,9 +163,10 @@ sandbox-demo/
     │   ├── module-info.java          # JPMS module descriptor
     │   ├── module-info.jguard        # jGuard policy (lives next to module-info.java)
     │   └── org/jguard/samples/sandbox/
-    │       ├── Main.java
-    │       ├── net/NetworkClient.java
-    │       └── worker/BackgroundWorker.java
+    │       ├── Main.java             # Demo runner
+    │       ├── net/NetworkClient.java          # Entitled to network.outbound
+    │       ├── worker/BackgroundWorker.java    # Entitled to threads.create
+    │       └── nativelib/NativeLoader.java     # Entitled to native.load
     └── test/java/
         └── org/jguard/samples/sandbox/
             └── EntitlementTest.java

--- a/samples/sandbox-demo/build.gradle
+++ b/samples/sandbox-demo/build.gradle
@@ -64,3 +64,8 @@ tasks.named("runWithAgent") {
   def jguardBuild = gradle.includedBuild("jguard")
   dependsOn(jguardBuild.task(":agent:jar"))
 }
+
+// Note: Enforcement testing is done via runWithAgent, not via a test task.
+// The jGuard agent conflicts with Gradle's test infrastructure because it
+// instruments classloaders, which interferes with Gradle's test workers.
+// Use: ./gradlew runWithAgent to see enforcement in action.

--- a/samples/sandbox-demo/src/main/java/module-info.jguard
+++ b/samples/sandbox-demo/src/main/java/module-info.jguard
@@ -21,7 +21,10 @@ security module org.jguard.samples.sandbox {
     // Grant network listen to specific packages
     entitle org.jguard.samples.sandbox.net to network.listen;
 
-    // Grant thread spawning to the worker package hierarchy
-    entitle org.jguard.samples.sandbox.worker.. to threads.spawn;
+    // Grant thread creation to the worker package hierarchy
+    entitle org.jguard.samples.sandbox.worker.. to threads.create;
+
+    // Grant native library loading to the nativelib package
+    entitle org.jguard.samples.sandbox.nativelib.. to native.load;
 
 }

--- a/samples/sandbox-demo/src/main/java/org/jguard/samples/sandbox/Main.java
+++ b/samples/sandbox-demo/src/main/java/org/jguard/samples/sandbox/Main.java
@@ -15,9 +15,13 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.jguard.core.JGuard;
+import org.jguard.samples.sandbox.nativelib.NativeLoader;
 import org.jguard.samples.sandbox.net.NetworkClient;
 import org.jguard.samples.sandbox.net.NetworkServer;
+import org.jguard.samples.sandbox.worker.BackgroundWorker;
 
 /**
  * Demonstrates jGuard capability-based security enforcement.
@@ -31,6 +35,8 @@ import org.jguard.samples.sandbox.net.NetworkServer;
  *   <li>network.outbound - outbound network connections (from org.jguard.samples.sandbox.net
  *       package)
  *   <li>network.listen - server socket binding (from org.jguard.samples.sandbox.net package)
+ *   <li>threads.create - thread creation (from org.jguard.samples.sandbox.worker package)
+ *   <li>native.load - native library loading (from org.jguard.samples.sandbox.nativelib package)
  * </ul>
  *
  * <h2>Running without the agent (no enforcement):</h2>
@@ -104,6 +110,26 @@ public final class Main {
 
     // Test 12: Server socket from non-entitled package (NOT ENTITLED)
     demonstrateUnentitledNetworkListenAccess();
+
+    // === THREAD TESTS ===
+    System.out.println("--- THREAD TESTS ---");
+    System.out.println();
+
+    // Test 13: Thread creation from entitled package (ENTITLED)
+    demonstrateEntitledThreadAccess();
+
+    // Test 14: Thread creation from non-entitled package (NOT ENTITLED)
+    demonstrateUnentitledThreadAccess();
+
+    // === NATIVE LIBRARY TESTS ===
+    System.out.println("--- NATIVE LIBRARY TESTS ---");
+    System.out.println();
+
+    // Test 15: Native library load from entitled package (ENTITLED)
+    demonstrateEntitledNativeAccess();
+
+    // Test 16: Native library load from non-entitled package (NOT ENTITLED)
+    demonstrateUnentitledNativeAccess();
   }
 
   /**
@@ -417,6 +443,112 @@ public final class Main {
       System.out.println("  BLOCKED (expected): " + e.getMessage());
     } catch (IOException e) {
       System.out.println("  ERROR: " + e.getMessage());
+    }
+
+    System.out.println();
+  }
+
+  /**
+   * Demonstrates thread creation from entitled package.
+   *
+   * <p>This operation IS entitled because it's called from the .worker package which has
+   * threads.create entitlement.
+   */
+  private static void demonstrateEntitledThreadAccess() {
+    System.out.println("[ENTITLED] threads.create (from .worker package)");
+    System.out.println("  Attempting to spawn a background task...");
+
+    try (BackgroundWorker worker = new BackgroundWorker()) {
+      // This call creates a thread FROM the BackgroundWorker class in the .worker package
+      // which HAS threads.create entitlement
+      Future<String> future = worker.submit(() -> "Hello from background thread!");
+      String result = future.get(5, TimeUnit.SECONDS);
+      System.out.println("  SUCCESS: Background task returned: " + result);
+    } catch (SecurityException e) {
+      System.out.println("  BLOCKED (unexpected): " + e.getMessage());
+    } catch (Exception e) {
+      System.out.println("  ERROR: " + e.getMessage());
+    }
+
+    System.out.println();
+  }
+
+  /**
+   * Demonstrates thread creation from non-entitled package.
+   *
+   * <p>This operation is NOT entitled because Main is in the sandbox package, not the .worker
+   * package. It should be blocked when the agent is active.
+   */
+  private static void demonstrateUnentitledThreadAccess() {
+    System.out.println("[NOT ENTITLED] threads.create (from main package)");
+    System.out.println("  Attempting to start a thread directly...");
+
+    try {
+      // This call is made FROM this class (Main) which is in the .sandbox package
+      // which does NOT have threads.create entitlement
+      Thread thread = new Thread(() -> System.out.println("  Thread running!"));
+      thread.start();
+      thread.join(1000);
+      System.out.println("  SUCCESS: Thread started and completed (unexpected!)");
+      System.out.println("  (This should be BLOCKED when running with the agent!)");
+    } catch (SecurityException e) {
+      System.out.println("  BLOCKED (expected): " + e.getMessage());
+    } catch (InterruptedException e) {
+      System.out.println("  ERROR: " + e.getMessage());
+    }
+
+    System.out.println();
+  }
+
+  /**
+   * Demonstrates native library loading from entitled package.
+   *
+   * <p>This operation IS entitled because it's called from the .nativelib package which has
+   * native.load entitlement.
+   */
+  private static void demonstrateEntitledNativeAccess() {
+    System.out.println("[ENTITLED] native.load (from .nativelib package)");
+    System.out.println("  Attempting to load a native library...");
+
+    try {
+      // This call is made FROM the NativeLoader class in the .nativelib package
+      // which HAS native.load entitlement
+      // Note: The library doesn't actually need to exist - we just test if the
+      // operation is allowed before it fails with UnsatisfiedLinkError
+      NativeLoader.tryLoadLibrary("nonexistent_test_lib");
+      System.out.println("  SUCCESS: Library load attempt allowed");
+    } catch (SecurityException e) {
+      System.out.println("  BLOCKED (unexpected): " + e.getMessage());
+    } catch (UnsatisfiedLinkError e) {
+      // This is expected - the library doesn't exist, but the operation was allowed
+      System.out.println("  SUCCESS: Load attempt allowed (library not found, as expected)");
+    }
+
+    System.out.println();
+  }
+
+  /**
+   * Demonstrates native library loading from non-entitled package.
+   *
+   * <p>This operation is NOT entitled because Main is in the sandbox package, not the .nativelib
+   * package. It should be blocked when the agent is active.
+   */
+  private static void demonstrateUnentitledNativeAccess() {
+    System.out.println("[NOT ENTITLED] native.load (from main package)");
+    System.out.println("  Attempting to load a native library directly...");
+
+    try {
+      // This call is made FROM this class (Main) which is in the .sandbox package
+      // which does NOT have native.load entitlement
+      System.loadLibrary("nonexistent_test_lib");
+      System.out.println("  SUCCESS: Library loaded (unexpected!)");
+      System.out.println("  (This should be BLOCKED when running with the agent!)");
+    } catch (SecurityException e) {
+      System.out.println("  BLOCKED (expected): " + e.getMessage());
+    } catch (UnsatisfiedLinkError e) {
+      // Library doesn't exist but operation was allowed - unexpected!
+      System.out.println("  SUCCESS: Load attempt allowed (library not found)");
+      System.out.println("  (This should be BLOCKED when running with the agent!)");
     }
 
     System.out.println();

--- a/samples/sandbox-demo/src/main/java/org/jguard/samples/sandbox/nativelib/NativeLoader.java
+++ b/samples/sandbox-demo/src/main/java/org/jguard/samples/sandbox/nativelib/NativeLoader.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The jGuard Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.jguard.samples.sandbox.nativelib;
+
+/**
+ * Native library loader entitled to load native libraries.
+ *
+ * <p>This class is in the {@code org.jguard.samples.sandbox.nativelib} package, which is entitled
+ * to {@code native.load} capability.
+ */
+public final class NativeLoader {
+
+  private NativeLoader() {
+    // Static utility class
+  }
+
+  /**
+   * Attempts to load a native library.
+   *
+   * <p>This method is entitled to native.load because it's in the .nativelib package.
+   *
+   * @param libraryName the name of the library to load
+   * @throws UnsatisfiedLinkError if the library cannot be found
+   * @throws SecurityException if not entitled to native.load (when agent is active)
+   */
+  public static void tryLoadLibrary(String libraryName) {
+    System.loadLibrary(libraryName);
+  }
+
+  /**
+   * Attempts to load a native library by path.
+   *
+   * <p>This method is entitled to native.load because it's in the .nativelib package.
+   *
+   * @param libraryPath the full path to the library
+   * @throws UnsatisfiedLinkError if the library cannot be loaded
+   * @throws SecurityException if not entitled to native.load (when agent is active)
+   */
+  public static void tryLoad(String libraryPath) {
+    System.load(libraryPath);
+  }
+}

--- a/samples/sandbox-demo/src/main/java/org/jguard/samples/sandbox/worker/BackgroundWorker.java
+++ b/samples/sandbox-demo/src/main/java/org/jguard/samples/sandbox/worker/BackgroundWorker.java
@@ -13,10 +13,10 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 /**
- * Background worker entitled to spawn threads.
+ * Background worker entitled to create threads.
  *
  * <p>This class is in the {@code org.jguard.samples.sandbox.worker} package,
- * which is entitled to {@code threads.spawn} capability (including subpackages).
+ * which is entitled to {@code threads.create} capability (including subpackages).
  */
 public final class BackgroundWorker implements AutoCloseable {
 

--- a/samples/sandbox-demo/src/test/java/org/jguard/samples/sandbox/EntitlementTest.java
+++ b/samples/sandbox-demo/src/test/java/org/jguard/samples/sandbox/EntitlementTest.java
@@ -7,27 +7,32 @@
  */
 package org.jguard.samples.sandbox;
 
-import org.jguard.samples.sandbox.net.NetworkClient;
-import org.jguard.samples.sandbox.worker.BackgroundWorker;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.jguard.samples.sandbox.net.NetworkClient;
+import org.jguard.samples.sandbox.nativelib.NativeLoader;
+import org.jguard.samples.sandbox.worker.BackgroundWorker;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
- * Tests for jGuard entitlement enforcement.
+ * Tests for jGuard entitlement verification.
  *
- * <p>These tests verify that operations succeed when entitled and fail when not.
- * Until enforcement is implemented, they serve as integration tests for the
- * sample code and as a template for enforcement testing.
+ * <p>These tests verify that entitled operations work correctly. To see enforcement (denial) of
+ * unentitled operations, run the Main class with the agent:
+ *
+ * <pre>{@code
+ * ./gradlew runWithAgent
+ * }</pre>
+ *
+ * <p>The Main class demonstrates both entitled and unentitled operations for all capabilities.
  */
 class EntitlementTest {
 
@@ -63,14 +68,6 @@ class EntitlementTest {
             assertThat(content).isEqualTo("hello jguard");
         }
 
-        // TODO: Once enforcement is implemented, add tests for denied operations:
-        // @Test
-        // @DisplayName("module cannot read files outside entitled paths")
-        // void cannotReadOutsideEntitledPaths() {
-        //     assertThatThrownBy(() -> Files.readString(Path.of("/etc/passwd")))
-        //         .isInstanceOf(SecurityException.class)
-        //         .hasMessageContaining("fs.read");
-        // }
     }
 
     @Nested
@@ -91,25 +88,16 @@ class EntitlementTest {
             assertThat(result).isIn(true, false);
         }
 
-        // TODO: Once enforcement is implemented, add tests for denied operations:
-        // @Test
-        // @DisplayName("main package cannot make outbound connections")
-        // void mainPackageCannotConnect() {
-        //     // Code in org.jguard.samples.sandbox (not .net) should be denied
-        //     assertThatThrownBy(() -> makeConnectionFromMainPackage())
-        //         .isInstanceOf(SecurityException.class)
-        //         .hasMessageContaining("network.outbound");
-        // }
     }
 
     @Nested
-    @DisplayName("threads.spawn entitlement")
-    class ThreadsSpawnTests {
+    @DisplayName("threads.create entitlement")
+    class ThreadsCreateTests {
 
         @Test
-        @DisplayName("worker package can spawn threads (entitled)")
-        void workerPackageCanSpawnThreads() throws Exception {
-            // Given: org.jguard.samples.sandbox.worker.. is entitled to threads.spawn
+        @DisplayName("worker package can create threads (entitled)")
+        void workerPackageCanCreateThreads() throws Exception {
+            // Given: org.jguard.samples.sandbox.worker.. is entitled to threads.create
             try (BackgroundWorker worker = new BackgroundWorker()) {
 
                 // When: we spawn a background task
@@ -121,15 +109,27 @@ class EntitlementTest {
             }
         }
 
-        // TODO: Once enforcement is implemented, add tests for denied operations:
-        // @Test
-        // @DisplayName("main package cannot spawn threads")
-        // void mainPackageCannotSpawnThreads() {
-        //     // Code in org.jguard.samples.sandbox (not .worker) should be denied
-        //     assertThatThrownBy(() -> new Thread(() -> {}).start())
-        //         .isInstanceOf(SecurityException.class)
-        //         .hasMessageContaining("threads.spawn");
-        // }
+    }
+
+    @Nested
+    @DisplayName("native.load entitlement")
+    class NativeLoadTests {
+
+        @Test
+        @DisplayName("nativelib package can load native libraries (entitled)")
+        void nativelibPackageCanLoadLibraries() {
+            // Given: org.jguard.samples.sandbox.nativelib.. is entitled to native.load
+            // When: we attempt to load a library from that package
+            // The library doesn't exist, but the operation should be ALLOWED
+            try {
+                NativeLoader.tryLoadLibrary("nonexistent_test_lib");
+            } catch (UnsatisfiedLinkError e) {
+                // Expected - library doesn't exist, but operation was allowed
+                assertThat(e.getMessage()).contains("nonexistent_test_lib");
+            }
+            // If we get here without SecurityException, the operation was allowed
+        }
+
     }
 
     @Nested


### PR DESCRIPTION
## Description
  New capabilities:
  - threads.create: Enforce thread creation via Thread.start() instrumentation
  - native.load: Enforce native library loading via System/Runtime.load/loadLibrary with optional pattern matching for library names

  Policy hot reload:
  - PolicyReloader watches policy file for changes at configurable interval
  - Atomic PolicyEnforcer swap via AtomicReference
  - Graceful handling of missing/corrupted policy files
  - Enable with -Djguard.reload=true -Djguard.reload.interval=5

  Architecture improvements:
  - Single dispatch via Operation enum and EnforcementCallback interface
  - Table-driven capability handling reduces duplication
  - Configurable skip prefixes for caller attribution

  Testing:
  - PolicyEnforcerTest covers SIMPLE, TARGET_PATTERN, PORT, FILESYSTEM categories
  - PolicyReloaderTest covers lifecycle, reload, and error scenarios
  - sandbox-demo demonstrates all 6 capabilities with entitled/unentitled examples

  Documentation:
  - Update EBNF spec with complete capability signatures
  - Fix policy syntax examples across all READMEs
  - Update DEVELOPMENT_PLAN.md with completed milestones M4.2-M6
