### PR TITLE
Add network host/port filtering for fine-grained access control

### DIFF
--- a/DEVELOPMENT_PLAN.md
+++ b/DEVELOPMENT_PLAN.md
@@ -18,7 +18,6 @@ Produce a credible **jGuard v0.1.0** that:
 * Full Java Security Manager parity
 * Complete API coverage
 * Reflection, classloading, or memory sandboxing
-* Complex network filtering (hosts/ports)
 * Container or OS integration
 
 ---
@@ -201,25 +200,34 @@ Exit criteria:
 
 Implementation:
 
-* `network.outbound` capability (0 arguments) grants outbound TCP connection rights
+* `network.outbound(host?, port?)` capability with optional host/port filtering
+  * `network.outbound` - allows any host, any port
+  * `network.outbound("*.example.com")` - host glob pattern, any port
+  * `network.outbound("*", 443)` - any host, specific port
+  * `network.outbound("*.example.com", "80-443")` - host pattern + port range
+* Host glob patterns: `*` matches one DNS segment, `**` matches one or more
+* Port specs: integer (`443`) or range string (`"80-443"`)
 * Instrumented classes:
   * `java.net.Socket` - constructors and connect() method
   * `java.nio.channels.SocketChannel` - connect() method
-* BootstrapEnforcer.onNetworkConnect() callbacks for enforcement
-* PolicyEnforcer.checkNetworkOutbound() for policy evaluation
+* BootstrapEnforcer.onNetworkConnect(host, port) callbacks for enforcement
+* PolicyEnforcer.checkNetworkOutbound(context, host, port) for policy evaluation
 * Retransformation support for bootstrap-loaded classes via DiscoveryStrategy.Reiterating
 
 Exit criteria:
 
 * demonstrable prevention of outbound socket creation ✓
+* demonstrable host/port filtering in sandbox-demo ✓
 
 ---
 
 ### M4.1 — Network Listen Enforcement ✓
 
-* `network.listen` capability grants server socket binding rights
+* `network.listen(port?)` capability grants server socket binding rights
   * `network.listen` (no arguments) - allows binding to any port
-  * `network.listen(port)` (1 integer argument) - allows binding to specific port only
+  * `network.listen(8080)` (integer) - allows binding to specific port only
+  * `network.listen("8080-8090")` (string range) - allows binding to port range
+* Port specs: integer (`8080`) or range string (`"8080-8090"`)
 * Instrumented classes:
   * `java.net.ServerSocket` - constructors and bind() method
   * `java.nio.channels.ServerSocketChannel` - bind() method
@@ -302,6 +310,36 @@ Benefits:
 
 ---
 
+### M4.6 — Network Host/Port Filtering ✓
+
+Enhanced `network.outbound` with host glob patterns and port range filtering:
+
+* **Host glob patterns**:
+  * `*` matches exactly one DNS segment (e.g., `*.example.com` matches `api.example.com`)
+  * `**` matches one or more segments (e.g., `**.example.com` matches `a.b.c.example.com`)
+  * Case-insensitive matching with IDN normalization
+* **Port specifications**:
+  * Integer: `443` for specific port
+  * String range: `"80-443"` for port range
+* New `HOST_PORT` operation category in bootstrap
+* `HostMatcher` utility for segment-based DNS matching
+* `PortRange` utility for port/range parsing and matching
+
+Implementation files:
+
+* `agent/src/main/java/org/jguard/agent/HostMatcher.java`
+* `agent/src/main/java/org/jguard/agent/PortRange.java`
+* Updated `PolicyValidator` for host/port semantic validation
+* Updated `PolicyEnforcer` with HOST_PORT category handler
+
+Exit criteria:
+
+* demonstrable host pattern filtering (allow `*.example.com`, deny `evil.com`) ✓
+* demonstrable port range filtering (allow `80-443`, deny `8080`) ✓
+* sandbox-demo includes RestrictedNetworkClient example ✓
+
+---
+
 ### M5 — Integration proof ✓
 
 * `samples/sandbox-demo` demonstrates full integration
@@ -344,7 +382,7 @@ Remaining for v0.1.0 release:
 |------------|--------|----------|
 | `fs.read(root, glob)` | ✓ | FILESYSTEM |
 | `fs.write(root, glob)` | ✓ | FILESYSTEM |
-| `network.outbound` | ✓ | SIMPLE |
+| `network.outbound(host?, port?)` | ✓ | HOST_PORT |
 | `network.listen(port?)` | ✓ | PORT |
 | `threads.create` | ✓ | SIMPLE |
 | `native.load(pattern?)` | ✓ | TARGET_PATTERN |
@@ -358,6 +396,8 @@ Additional features:
 | Single dispatch architecture | ✓ |
 | Gradle plugin with runWithAgent | ✓ |
 | Comprehensive documentation | ✓ |
+| Network host/port filtering | ✓ |
+| Port range support | ✓ |
 
 ---
 
@@ -406,6 +446,5 @@ Potential additions:
 
 * `env.read` / `env.write` — environment variable access
 * `classloader.create` — custom classloader creation
-* Network host/port filtering for `network.outbound`
 * `system.property.read` / `system.property.write` — system property access
 

--- a/README.md
+++ b/README.md
@@ -128,10 +128,16 @@ Examples include:
 
 * `fs.read(root, glob)` — read files matching glob pattern under root
 * `fs.write(root, glob)` — write files matching glob pattern under root
-* `network.outbound` — open outbound network connections
-* `network.listen` — bind server sockets to ports
+* `network.outbound(hostPattern?, portSpec?)` — open outbound network connections with optional host/port filtering
+* `network.listen(portSpec?)` — bind server sockets to ports (supports port ranges)
 * `threads.create` — create new threads
-* `native.load` — load native libraries
+* `native.load(pattern?)` — load native libraries
+
+**Host patterns** for `network.outbound`:
+* `*` — matches one DNS segment (e.g., `*.example.com`)
+* `**` — matches one or more DNS segments (e.g., `**.example.com`)
+
+**Port specs** can be integers (`443`) or ranges (`"80-443"`).
 
 Capabilities are intentionally narrow and composable.
 

--- a/agent-bootstrap/src/main/java/org/jguard/bootstrap/BootstrapEnforcer.java
+++ b/agent-bootstrap/src/main/java/org/jguard/bootstrap/BootstrapEnforcer.java
@@ -387,6 +387,7 @@ public final class BootstrapEnforcer {
       case SIMPLE -> arg0 != null ? arg0 + ":" + arg1 : "n/a";
       case PORT -> "port=" + arg1;
       case TARGET_PATTERN -> arg0 != null ? String.valueOf(arg0) : "any";
+      case HOST_PORT -> (arg0 != null ? arg0 : "*") + ":" + arg1;
     };
   }
 
@@ -402,6 +403,7 @@ public final class BootstrapEnforcer {
       case SIMPLE -> true; // No strict type requirement
       case PORT -> true; // arg0 is null, arg1 is port
       case TARGET_PATTERN -> arg0 == null || arg0 instanceof String;
+      case HOST_PORT -> arg0 == null || arg0 instanceof String; // arg0 is host, arg1 is port
     };
   }
 

--- a/agent-bootstrap/src/main/java/org/jguard/bootstrap/Operation.java
+++ b/agent-bootstrap/src/main/java/org/jguard/bootstrap/Operation.java
@@ -47,7 +47,7 @@ public enum Operation {
    *
    * <p>Arguments: {@code arg0} = String host, {@code arg1} = port
    */
-  NET_CONNECT("network.outbound", Category.SIMPLE),
+  NET_CONNECT("network.outbound", Category.HOST_PORT),
 
   /**
    * Network listen (server socket bind).
@@ -91,11 +91,28 @@ public enum Operation {
     SIMPLE,
 
     /**
-     * Port-based capabilities with optional port restriction.
+     * Port-based capabilities with optional port or port-range restriction.
      *
-     * <p>Policy args: none (any port) or {@code (port)} for specific port.
+     * <p>Policy args: none (any port), {@code (port)} for specific port, or {@code ("start-end")}
+     * for port range.
      */
     PORT,
+
+    /**
+     * Host and port filtering capabilities.
+     *
+     * <p>Policy args: none (any host/port), {@code (hostPattern)} for host filtering, {@code
+     * (hostPattern, port)} or {@code (hostPattern, "start-end")} for both.
+     *
+     * <p>Host patterns support:
+     *
+     * <ul>
+     *   <li>{@code *} - any single DNS segment
+     *   <li>{@code **} - one or more DNS segments
+     *   <li>Literal segments for exact matching
+     * </ul>
+     */
+    HOST_PORT,
 
     /**
      * Target pattern capabilities with optional pattern matching.

--- a/agent/README.md
+++ b/agent/README.md
@@ -215,12 +215,18 @@ Runtime native loading is instrumented:
 
 The following capabilities are fully enforced:
 
-- `fs.read` — filesystem read operations
-- `fs.write` — filesystem write operations
-- `network.outbound` — outbound socket connections
-- `network.listen` — server socket binding
+- `fs.read(root, glob)` — filesystem read operations
+- `fs.write(root, glob)` — filesystem write operations
+- `network.outbound(hostPattern?, portSpec?)` — outbound socket connections with optional host/port filtering
+- `network.listen(portSpec?)` — server socket binding with optional port or port range
 - `threads.create` — thread creation
-- `native.load` — native library loading
+- `native.load(pattern?)` — native library loading
+
+**Host patterns** for `network.outbound`:
+- `*` matches exactly one DNS segment (e.g., `*.example.com` matches `api.example.com`)
+- `**` matches one or more DNS segments (e.g., `**.example.com` matches `a.b.c.example.com`)
+
+**Port specs** can be integers (`443`) or ranges (`"8080-8090"`).
 
 ### JVM Bootstrap Operations
 

--- a/agent/src/main/java/org/jguard/agent/HostMatcher.java
+++ b/agent/src/main/java/org/jguard/agent/HostMatcher.java
@@ -1,0 +1,163 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The jGuard Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.jguard.agent;
+
+import java.net.IDN;
+import java.util.Locale;
+
+/**
+ * Matches host strings against glob patterns for network capability enforcement.
+ *
+ * <h2>Pattern Syntax</h2>
+ *
+ * <ul>
+ *   <li>{@code *} - matches exactly one DNS label (segment)
+ *   <li>{@code **} - matches one or more DNS labels (any depth)
+ *   <li>Literal segments match exactly (case-insensitive)
+ * </ul>
+ *
+ * <h2>Examples</h2>
+ *
+ * <table border="1">
+ *   <caption>Host pattern matching examples</caption>
+ *   <tr><th>Pattern</th><th>Matches</th><th>Does NOT Match</th></tr>
+ *   <tr><td>{@code *}</td><td>any host</td><td>-</td></tr>
+ *   <tr><td>{@code example.com}</td><td>example.com</td><td>foo.example.com</td></tr>
+ *   <tr><td>{@code *.example.com}</td><td>api.example.com</td><td>example.com, a.b.example.com</td></tr>
+ *   <tr><td>{@code **.example.com}</td><td>api.example.com, a.b.c.example.com</td><td>example.com</td></tr>
+ * </table>
+ *
+ * <h2>Normalization</h2>
+ *
+ * <p>Both host and pattern are normalized before matching:
+ *
+ * <ul>
+ *   <li>Lowercase
+ *   <li>Trim whitespace
+ *   <li>Strip trailing dot ({@code example.com.} → {@code example.com})
+ *   <li>Strip IPv6 brackets ({@code [::1]} → {@code ::1})
+ *   <li>IDN to ASCII ({@code münchen.de} → {@code xn--mnchen-3ya.de})
+ * </ul>
+ */
+public final class HostMatcher {
+
+  private HostMatcher() {
+    // Utility class
+  }
+
+  /**
+   * Normalizes a host string for matching.
+   *
+   * @param host the host string (may be null)
+   * @return normalized host, or empty string if null/blank
+   */
+  public static String normalize(String host) {
+    if (host == null || host.isBlank()) {
+      return "";
+    }
+
+    String h = host.trim().toLowerCase(Locale.ROOT);
+
+    // Strip trailing dot (FQDN notation)
+    if (h.endsWith(".")) {
+      h = h.substring(0, h.length() - 1);
+    }
+
+    // Strip IPv6 brackets
+    if (h.startsWith("[") && h.endsWith("]")) {
+      h = h.substring(1, h.length() - 1);
+    }
+
+    // Convert IDN to ASCII (Punycode)
+    try {
+      h = IDN.toASCII(h, IDN.ALLOW_UNASSIGNED);
+    } catch (IllegalArgumentException e) {
+      // Keep as-is if IDN conversion fails
+    }
+
+    return h;
+  }
+
+  /**
+   * Matches a host against a glob pattern.
+   *
+   * <p>Both host and pattern are normalized before matching.
+   *
+   * @param host the host to match (hostname or IP address)
+   * @param pattern the glob pattern
+   * @return true if host matches pattern
+   */
+  public static boolean matches(String host, String pattern) {
+    String normalizedHost = normalize(host);
+    String normalizedPattern = normalize(pattern);
+
+    // "*" matches any host
+    if ("*".equals(normalizedPattern)) {
+      return true;
+    }
+
+    // Empty/null host only matches "*"
+    if (normalizedHost.isEmpty()) {
+      return false;
+    }
+
+    String[] hostSegments = normalizedHost.split("\\.");
+    String[] patternSegments = normalizedPattern.split("\\.");
+
+    return matchSegments(hostSegments, 0, patternSegments, 0);
+  }
+
+  /**
+   * Recursively matches host segments against pattern segments.
+   *
+   * @param host host segments
+   * @param hi current host index
+   * @param pattern pattern segments
+   * @param pi current pattern index
+   * @return true if remaining segments match
+   */
+  private static boolean matchSegments(String[] host, int hi, String[] pattern, int pi) {
+    // Base case: both exhausted - match!
+    if (hi == host.length && pi == pattern.length) {
+      return true;
+    }
+
+    // Pattern exhausted but host has more - no match
+    if (pi == pattern.length) {
+      return false;
+    }
+
+    // Host exhausted but pattern has more - no match
+    // (** requires one-or-more segments, so we can't match with zero remaining)
+    if (hi == host.length) {
+      return false;
+    }
+
+    String p = pattern[pi];
+
+    if ("**".equals(p)) {
+      // ** matches one or more segments
+      // Try matching 1, 2, 3, ... segments
+      for (int skip = 1; hi + skip <= host.length; skip++) {
+        if (matchSegments(host, hi + skip, pattern, pi + 1)) {
+          return true;
+        }
+      }
+      return false;
+    } else if ("*".equals(p)) {
+      // * matches exactly one segment
+      return matchSegments(host, hi + 1, pattern, pi + 1);
+    } else {
+      // Literal segment - must match exactly
+      if (!host[hi].equals(p)) {
+        return false;
+      }
+      return matchSegments(host, hi + 1, pattern, pi + 1);
+    }
+  }
+}

--- a/agent/src/main/java/org/jguard/agent/PolicyEnforcer.java
+++ b/agent/src/main/java/org/jguard/agent/PolicyEnforcer.java
@@ -87,18 +87,26 @@ public final class PolicyEnforcer {
       return deniedModuleMismatch(callerPackage, callerModule, formatDetails(op, arg0, arg1));
     }
 
-    // Build cache key
+    // Build cache key (may be null for high-cardinality operations like HOST_PORT)
     String cacheKey = buildCacheKey(callerPackage, callerModule, op, arg0, arg1);
-    Boolean cached = decisionCache.get(cacheKey);
-    if (cached != null) {
-      return cached
-          ? null
-          : denied(callerPackage, op.capabilityName(), formatDetails(op, arg0, arg1));
+
+    // Check cache if key is available
+    if (cacheKey != null) {
+      Boolean cached = decisionCache.get(cacheKey);
+      if (cached != null) {
+        return cached
+            ? null
+            : denied(callerPackage, op.capabilityName(), formatDetails(op, arg0, arg1));
+      }
     }
 
     // Check entitlements
     boolean allowed = isAllowed(callerPackage, op, arg0, arg1);
-    decisionCache.put(cacheKey, allowed);
+
+    // Cache result if key is available
+    if (cacheKey != null) {
+      decisionCache.put(cacheKey, allowed);
+    }
 
     return allowed
         ? null
@@ -119,6 +127,10 @@ public final class PolicyEnforcer {
       case SIMPLE -> op.capabilityName();
       case PORT -> "port " + arg1;
       case TARGET_PATTERN -> arg0 != null ? arg0.toString() : "any target";
+      case HOST_PORT -> {
+        String host = arg0 != null ? arg0.toString() : "*";
+        yield host + ":" + arg1;
+      }
     };
   }
 
@@ -134,8 +146,9 @@ public final class PolicyEnforcer {
     return switch (op.category()) {
       case FILESYSTEM -> base + ":" + ((Path) arg0).toAbsolutePath();
       case SIMPLE -> base;
-      case PORT -> base + ":" + arg1;
+      case PORT -> base + ":" + arg1; // Include port for caching
       case TARGET_PATTERN -> base + ":" + (arg0 != null ? arg0 : "any");
+      case HOST_PORT -> null; // Don't cache HOST_PORT - high cardinality hosts
     };
   }
 
@@ -152,6 +165,7 @@ public final class PolicyEnforcer {
       case SIMPLE -> isAllowedSimple(callerPackage, capability);
       case PORT -> isAllowedPort(callerPackage, arg1, capability);
       case TARGET_PATTERN -> isAllowedTargetPattern(callerPackage, (String) arg0, capability);
+      case HOST_PORT -> isAllowedHostPort(callerPackage, (String) arg0, arg1, capability);
     };
   }
 
@@ -210,9 +224,11 @@ public final class PolicyEnforcer {
   }
 
   /**
-   * Handles PORT category - optional port restriction.
+   * Handles PORT category - optional port or port-range restriction.
    *
    * <p>Used for: network.listen
+   *
+   * <p>Port 0 (ephemeral) is only allowed if the entitlement explicitly includes it.
    */
   private boolean isAllowedPort(String callerPackage, int port, String capability) {
     for (Entitlement entitlement : policy.entitlements()) {
@@ -225,7 +241,7 @@ public final class PolicyEnforcer {
 
       List<CapabilityArgument> args = entitlement.capability().arguments();
       if (args.isEmpty()) {
-        // No arguments - allows any port
+        // No arguments - allows any port (including port 0)
         LOG.debug(
             "{} allowed (any port): package={}, port={}, entitlement={}",
             capability,
@@ -234,15 +250,15 @@ public final class PolicyEnforcer {
             entitlement);
         return true;
       } else if (args.size() == 1) {
-        // Specific port restriction
-        long allowedPort = ((CapabilityArgument.IntegerArg) args.get(0)).value();
-        if (port == allowedPort || port == 0) {
-          // Port 0 means "any available port" - allow if they have any entitlement
+        // Port or port-range restriction
+        PortRange range = parsePortArg(args.get(0));
+        if (range.contains(port)) {
           LOG.debug(
-              "{} allowed (port match): package={}, port={}, entitlement={}",
+              "{} allowed (port match): package={}, port={}, range={}, entitlement={}",
               capability,
               callerPackage,
               port,
+              range,
               entitlement);
           return true;
         }
@@ -251,6 +267,89 @@ public final class PolicyEnforcer {
 
     LOG.debug("{} denied: package={}, port={}", capability, callerPackage, port);
     return false;
+  }
+
+  /**
+   * Handles HOST_PORT category - host glob + port/port-range filtering.
+   *
+   * <p>Used for: network.outbound
+   *
+   * <p>Port 0 is not a valid destination for outbound connections and is always denied.
+   */
+  private boolean isAllowedHostPort(
+      String callerPackage, String host, int port, String capability) {
+    // Port 0 is not a valid destination for outbound connections
+    if (port == 0) {
+      LOG.debug("{} denied: port 0 is invalid destination", capability);
+      return false;
+    }
+
+    for (Entitlement entitlement : policy.entitlements()) {
+      if (!entitlement.capability().name().equals(capability)) {
+        continue;
+      }
+      if (!subjectMatches(entitlement.subject(), callerPackage)) {
+        continue;
+      }
+
+      List<CapabilityArgument> args = entitlement.capability().arguments();
+
+      if (args.isEmpty()) {
+        // No args = any host, any port
+        LOG.debug(
+            "{} allowed (any host/port): package={}, host={}, port={}, entitlement={}",
+            capability,
+            callerPackage,
+            host,
+            port,
+            entitlement);
+        return true;
+      }
+
+      String hostPattern = "*";
+      PortRange portRange = PortRange.any();
+
+      if (args.size() >= 1) {
+        hostPattern = getStringArg(args.get(0));
+      }
+      if (args.size() >= 2) {
+        portRange = parsePortArg(args.get(1));
+      }
+
+      if (HostMatcher.matches(host, hostPattern) && portRange.contains(port)) {
+        LOG.debug(
+            "{} allowed: package={}, host={}, port={}, hostPattern={}, portRange={}, entitlement={}",
+            capability,
+            callerPackage,
+            host,
+            port,
+            hostPattern,
+            portRange,
+            entitlement);
+        return true;
+      }
+    }
+
+    LOG.debug("{} denied: package={}, host={}, port={}", capability, callerPackage, host, port);
+    return false;
+  }
+
+  private PortRange parsePortArg(CapabilityArgument arg) {
+    if (arg instanceof CapabilityArgument.IntegerArg intArg) {
+      return PortRange.single((int) intArg.value());
+    } else if (arg instanceof CapabilityArgument.StringArg strArg) {
+      return PortRange.parse(strArg.value());
+    }
+    throw new IllegalArgumentException("Invalid port argument: " + arg);
+  }
+
+  private String getStringArg(CapabilityArgument arg) {
+    if (arg instanceof CapabilityArgument.StringArg strArg) {
+      return strArg.value();
+    } else if (arg instanceof CapabilityArgument.IntegerArg) {
+      throw new IllegalArgumentException("Expected string argument, got integer: " + arg);
+    }
+    throw new IllegalArgumentException("Invalid argument: " + arg);
   }
 
   /**

--- a/agent/src/main/java/org/jguard/agent/PortRange.java
+++ b/agent/src/main/java/org/jguard/agent/PortRange.java
@@ -1,0 +1,132 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The jGuard Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.jguard.agent;
+
+/**
+ * Represents a port or port range for network capability matching.
+ *
+ * <p>Supports both single ports and ranges:
+ *
+ * <ul>
+ *   <li>{@code "8080"} - single port
+ *   <li>{@code "80-443"} - port range (inclusive)
+ * </ul>
+ *
+ * @param start the start port (inclusive)
+ * @param end the end port (inclusive)
+ */
+public record PortRange(int start, int end) {
+
+  private static final int MIN_PORT = 0;
+  private static final int MAX_PORT = 65535;
+
+  /**
+   * Creates a PortRange with validation.
+   *
+   * @throws IllegalArgumentException if ports are out of range or start > end
+   */
+  public PortRange {
+    if (start < MIN_PORT || start > MAX_PORT) {
+      throw new IllegalArgumentException("Start port out of range (0-65535): " + start);
+    }
+    if (end < MIN_PORT || end > MAX_PORT) {
+      throw new IllegalArgumentException("End port out of range (0-65535): " + end);
+    }
+    if (start > end) {
+      throw new IllegalArgumentException(
+          "Start port cannot be greater than end port: " + start + "-" + end);
+    }
+  }
+
+  /**
+   * Parses a port specification string.
+   *
+   * @param spec port spec like "8080" or "80-443"
+   * @return the parsed PortRange
+   * @throws IllegalArgumentException if spec is invalid
+   */
+  public static PortRange parse(String spec) {
+    if (spec == null || spec.isEmpty()) {
+      throw new IllegalArgumentException("Port spec cannot be null or empty");
+    }
+
+    String trimmed = spec.trim();
+    if (!trimmed.equals(spec)) {
+      throw new IllegalArgumentException(
+          "Port spec cannot have leading/trailing whitespace: '" + spec + "'");
+    }
+
+    int dashIndex = spec.indexOf('-');
+    if (dashIndex == -1) {
+      // Single port
+      int port = parsePort(spec);
+      return new PortRange(port, port);
+    }
+
+    // Range: split on dash
+    if (dashIndex == 0) {
+      throw new IllegalArgumentException("Invalid port spec (starts with dash): " + spec);
+    }
+    if (dashIndex == spec.length() - 1) {
+      throw new IllegalArgumentException("Invalid port spec (ends with dash): " + spec);
+    }
+
+    String startStr = spec.substring(0, dashIndex);
+    String endStr = spec.substring(dashIndex + 1);
+
+    int start = parsePort(startStr);
+    int end = parsePort(endStr);
+
+    return new PortRange(start, end);
+  }
+
+  private static int parsePort(String s) {
+    try {
+      return Integer.parseInt(s);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("Invalid port number: " + s);
+    }
+  }
+
+  /**
+   * Creates a PortRange for a single port.
+   *
+   * @param port the port number
+   * @return a PortRange representing exactly this port
+   */
+  public static PortRange single(int port) {
+    return new PortRange(port, port);
+  }
+
+  /**
+   * Returns a PortRange that matches any valid port (0-65535).
+   *
+   * @return a PortRange covering all ports
+   */
+  public static PortRange any() {
+    return new PortRange(MIN_PORT, MAX_PORT);
+  }
+
+  /**
+   * Checks if this range contains the given port.
+   *
+   * @param port the port to check
+   * @return true if port is within this range (inclusive)
+   */
+  public boolean contains(int port) {
+    return port >= start && port <= end;
+  }
+
+  @Override
+  public String toString() {
+    if (start == end) {
+      return String.valueOf(start);
+    }
+    return start + "-" + end;
+  }
+}

--- a/agent/src/test/java/org/jguard/agent/HostMatcherTest.java
+++ b/agent/src/test/java/org/jguard/agent/HostMatcherTest.java
@@ -1,0 +1,337 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The jGuard Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.jguard.agent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link HostMatcher}. */
+class HostMatcherTest {
+
+  @Nested
+  @DisplayName("Single-level wildcard (*)")
+  class SingleLevelWildcardTests {
+
+    @Test
+    @DisplayName("*.example.com matches api.example.com")
+    void matchesSingleSubdomain() {
+      assertThat(HostMatcher.matches("api.example.com", "*.example.com")).isTrue();
+    }
+
+    @Test
+    @DisplayName("*.example.com does NOT match example.com")
+    void doesNotMatchBaseWithStar() {
+      assertThat(HostMatcher.matches("example.com", "*.example.com")).isFalse();
+    }
+
+    @Test
+    @DisplayName("*.example.com does NOT match a.b.example.com")
+    void doesNotMatchTooDeep() {
+      assertThat(HostMatcher.matches("a.b.example.com", "*.example.com")).isFalse();
+    }
+
+    @Test
+    @DisplayName("api.*.example.com matches api.foo.example.com")
+    void internalWildcardMatches() {
+      assertThat(HostMatcher.matches("api.foo.example.com", "api.*.example.com")).isTrue();
+    }
+
+    @Test
+    @DisplayName("api.*.example.com does NOT match api.example.com")
+    void internalWildcardRequiresSegment() {
+      assertThat(HostMatcher.matches("api.example.com", "api.*.example.com")).isFalse();
+    }
+
+    @Test
+    @DisplayName("api.*.example.com does NOT match api.x.y.example.com")
+    void internalWildcardMatchesOnlyOne() {
+      assertThat(HostMatcher.matches("api.x.y.example.com", "api.*.example.com")).isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("Multi-level wildcard (**)")
+  class MultiLevelWildcardTests {
+
+    @Test
+    @DisplayName("**.example.com matches api.example.com")
+    void matchesSingleLevel() {
+      assertThat(HostMatcher.matches("api.example.com", "**.example.com")).isTrue();
+    }
+
+    @Test
+    @DisplayName("**.example.com matches a.b.c.example.com")
+    void matchesMultipleLevels() {
+      assertThat(HostMatcher.matches("a.b.c.example.com", "**.example.com")).isTrue();
+    }
+
+    @Test
+    @DisplayName("**.example.com does NOT match example.com")
+    void doesNotMatchBaseDomain() {
+      // ** requires one-or-more segments
+      assertThat(HostMatcher.matches("example.com", "**.example.com")).isFalse();
+    }
+
+    @Test
+    @DisplayName("api.**.example.com matches api.foo.example.com")
+    void internalDoubleStarMatchesOne() {
+      assertThat(HostMatcher.matches("api.foo.example.com", "api.**.example.com")).isTrue();
+    }
+
+    @Test
+    @DisplayName("api.**.example.com matches api.x.y.z.example.com")
+    void internalDoubleStarMatchesMany() {
+      assertThat(HostMatcher.matches("api.x.y.z.example.com", "api.**.example.com")).isTrue();
+    }
+
+    @Test
+    @DisplayName("api.**.example.com does NOT match api.example.com")
+    void internalDoubleStarRequiresOneOrMore() {
+      assertThat(HostMatcher.matches("api.example.com", "api.**.example.com")).isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("Universal wildcard")
+  class UniversalWildcardTests {
+
+    @Test
+    @DisplayName("* matches any hostname")
+    void starMatchesAnyHostname() {
+      assertThat(HostMatcher.matches("example.com", "*")).isTrue();
+      assertThat(HostMatcher.matches("api.example.com", "*")).isTrue();
+      assertThat(HostMatcher.matches("a.b.c.d.example.com", "*")).isTrue();
+    }
+
+    @Test
+    @DisplayName("* matches IP address")
+    void starMatchesIpAddress() {
+      assertThat(HostMatcher.matches("93.184.216.34", "*")).isTrue();
+      assertThat(HostMatcher.matches("::1", "*")).isTrue();
+    }
+
+    @Test
+    @DisplayName("** alone matches any hostname with 1+ segments (but not null/empty)")
+    void doubleStarAloneMatchesAnyNonEmpty() {
+      // ** as a standalone pattern matches any host with at least one segment
+      // This is similar to * but with key difference: * matches null/empty, ** doesn't
+      assertThat(HostMatcher.matches("example.com", "**")).isTrue();
+      assertThat(HostMatcher.matches("api.example.com", "**")).isTrue();
+      assertThat(HostMatcher.matches("localhost", "**")).isTrue();
+
+      // Unlike *, ** does NOT match null/empty
+      assertThat(HostMatcher.matches(null, "**")).isFalse();
+      assertThat(HostMatcher.matches("", "**")).isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("Exact match")
+  class ExactMatchTests {
+
+    @Test
+    @DisplayName("exact pattern matches exact host")
+    void exactMatch() {
+      assertThat(HostMatcher.matches("example.com", "example.com")).isTrue();
+      assertThat(HostMatcher.matches("api.example.com", "api.example.com")).isTrue();
+    }
+
+    @Test
+    @DisplayName("exact pattern does NOT match subdomain")
+    void exactDoesNotMatchSubdomain() {
+      assertThat(HostMatcher.matches("api.example.com", "example.com")).isFalse();
+    }
+
+    @Test
+    @DisplayName("exact pattern does NOT match parent domain")
+    void exactDoesNotMatchParent() {
+      assertThat(HostMatcher.matches("example.com", "api.example.com")).isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("Case insensitivity")
+  class CaseInsensitivityTests {
+
+    @Test
+    @DisplayName("matching is case-insensitive for host")
+    void caseInsensitiveHost() {
+      assertThat(HostMatcher.matches("API.Example.COM", "*.example.com")).isTrue();
+    }
+
+    @Test
+    @DisplayName("matching is case-insensitive for pattern")
+    void caseInsensitivePattern() {
+      assertThat(HostMatcher.matches("api.example.com", "*.EXAMPLE.COM")).isTrue();
+    }
+
+    @Test
+    @DisplayName("exact match is case-insensitive")
+    void caseInsensitiveExact() {
+      assertThat(HostMatcher.matches("EXAMPLE.COM", "example.com")).isTrue();
+    }
+  }
+
+  @Nested
+  @DisplayName("Normalization")
+  class NormalizationTests {
+
+    @Test
+    @DisplayName("host with trailing dot is normalized")
+    void trailingDotNormalized() {
+      assertThat(HostMatcher.matches("api.example.com.", "*.example.com")).isTrue();
+    }
+
+    @Test
+    @DisplayName("pattern with trailing dot is normalized")
+    void patternTrailingDotNormalized() {
+      assertThat(HostMatcher.matches("api.example.com", "*.example.com.")).isTrue();
+    }
+
+    @Test
+    @DisplayName("IPv6 brackets are stripped")
+    void ipv6BracketsStripped() {
+      assertThat(HostMatcher.normalize("[::1]")).isEqualTo("::1");
+      assertThat(HostMatcher.matches("[::1]", "::1")).isTrue();
+    }
+
+    @Test
+    @DisplayName("whitespace is trimmed")
+    void whitespaceTrimmed() {
+      assertThat(HostMatcher.normalize("  example.com  ")).isEqualTo("example.com");
+    }
+
+    @Test
+    @DisplayName("null host returns empty string")
+    void nullReturnsEmpty() {
+      assertThat(HostMatcher.normalize(null)).isEqualTo("");
+    }
+
+    @Test
+    @DisplayName("blank host returns empty string")
+    void blankReturnsEmpty() {
+      assertThat(HostMatcher.normalize("   ")).isEqualTo("");
+    }
+  }
+
+  @Nested
+  @DisplayName("Null and empty host handling")
+  class NullAndEmptyTests {
+
+    @Test
+    @DisplayName("null host matches only *")
+    void nullMatchesOnlyStar() {
+      assertThat(HostMatcher.matches(null, "*")).isTrue();
+      assertThat(HostMatcher.matches(null, "example.com")).isFalse();
+      assertThat(HostMatcher.matches(null, "*.example.com")).isFalse();
+    }
+
+    @Test
+    @DisplayName("empty host matches only *")
+    void emptyMatchesOnlyStar() {
+      assertThat(HostMatcher.matches("", "*")).isTrue();
+      assertThat(HostMatcher.matches("", "example.com")).isFalse();
+    }
+
+    @Test
+    @DisplayName("blank host matches only *")
+    void blankMatchesOnlyStar() {
+      assertThat(HostMatcher.matches("   ", "*")).isTrue();
+      assertThat(HostMatcher.matches("   ", "example.com")).isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("IP address handling")
+  class IpAddressTests {
+
+    @Test
+    @DisplayName("* matches IPv4 address")
+    void starMatchesIpv4() {
+      assertThat(HostMatcher.matches("93.184.216.34", "*")).isTrue();
+    }
+
+    @Test
+    @DisplayName("* matches IPv6 address")
+    void starMatchesIpv6() {
+      assertThat(HostMatcher.matches("2606:2800:220:1:248:1893:25c8:1946", "*")).isTrue();
+    }
+
+    @Test
+    @DisplayName("exact IPv4 match works")
+    void exactIpv4Match() {
+      assertThat(HostMatcher.matches("93.184.216.34", "93.184.216.34")).isTrue();
+    }
+
+    @Test
+    @DisplayName("IP wildcard pattern works for octets")
+    void ipWildcardPattern() {
+      // IP addresses are dot-separated, so segment matching works
+      assertThat(HostMatcher.matches("192.168.1.100", "192.168.*.*")).isTrue();
+      assertThat(HostMatcher.matches("10.0.0.1", "192.168.*.*")).isFalse();
+    }
+
+    @Test
+    @DisplayName("IP pattern does NOT match hostname")
+    void ipPatternDoesNotMatchHostname() {
+      assertThat(HostMatcher.matches("example.com", "93.184.*.*")).isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("Edge cases")
+  class EdgeCaseTests {
+
+    @Test
+    @DisplayName("single segment host")
+    void singleSegmentHost() {
+      assertThat(HostMatcher.matches("localhost", "localhost")).isTrue();
+      assertThat(HostMatcher.matches("localhost", "*")).isTrue();
+      assertThat(HostMatcher.matches("localhost", "*.example.com")).isFalse();
+    }
+
+    @Test
+    @DisplayName("deeply nested host")
+    void deeplyNestedHost() {
+      String deep = "a.b.c.d.e.f.g.example.com";
+      assertThat(HostMatcher.matches(deep, "**.example.com")).isTrue();
+      assertThat(HostMatcher.matches(deep, "*.example.com")).isFalse();
+    }
+
+    @Test
+    @DisplayName("pattern longer than host")
+    void patternLongerThanHost() {
+      assertThat(HostMatcher.matches("example.com", "api.sub.example.com")).isFalse();
+    }
+
+    @Test
+    @DisplayName("host longer than pattern")
+    void hostLongerThanPattern() {
+      assertThat(HostMatcher.matches("api.sub.example.com", "example.com")).isFalse();
+    }
+
+    @Test
+    @DisplayName("** at end of pattern")
+    void doubleStarAtEnd() {
+      assertThat(HostMatcher.matches("api.example.com", "api.**")).isTrue();
+      assertThat(HostMatcher.matches("api.a.b.c", "api.**")).isTrue();
+      assertThat(HostMatcher.matches("api", "api.**")).isFalse(); // ** needs at least one
+    }
+
+    @Test
+    @DisplayName("multiple * wildcards")
+    void multipleStarWildcards() {
+      assertThat(HostMatcher.matches("a.b.c", "*.*.*")).isTrue();
+      assertThat(HostMatcher.matches("a.b", "*.*.*")).isFalse();
+      assertThat(HostMatcher.matches("a.b.c.d", "*.*.*")).isFalse();
+    }
+  }
+}

--- a/agent/src/test/java/org/jguard/agent/PolicyEnforcerTest.java
+++ b/agent/src/test/java/org/jguard/agent/PolicyEnforcerTest.java
@@ -448,7 +448,7 @@ class PolicyEnforcerTest {
       PolicyEnforcer enforcer = createEnforcer(policy);
 
       assertThatCode(
-              () -> checkOperation(enforcer, caller("com.example.app"), Operation.NET_CONNECT))
+              () -> checkNetworkOutbound(enforcer, caller("com.example.app"), "example.com", 80))
           .doesNotThrowAnyException();
     }
 
@@ -460,7 +460,7 @@ class PolicyEnforcerTest {
       PolicyEnforcer enforcer = createEnforcer(policy);
 
       assertThatThrownBy(
-              () -> checkOperation(enforcer, caller("com.example.app"), Operation.NET_CONNECT))
+              () -> checkNetworkOutbound(enforcer, caller("com.example.app"), "example.com", 80))
           .isInstanceOf(SecurityException.class)
           .hasMessageContaining("network.outbound");
     }
@@ -656,10 +656,6 @@ class PolicyEnforcerTest {
       assertThatCode(() -> checkNetworkListen(enforcer, caller("com.example.app"), 8080))
           .doesNotThrowAnyException();
 
-      // Ephemeral port (0) allowed with any entitlement
-      assertThatCode(() -> checkNetworkListen(enforcer, caller("com.example.app"), 0))
-          .doesNotThrowAnyException();
-
       // Different port denied
       assertThatThrownBy(() -> checkNetworkListen(enforcer, caller("com.example.app"), 9090))
           .isInstanceOf(SecurityException.class);
@@ -735,6 +731,373 @@ class PolicyEnforcerTest {
     SecurityException denial = enforcer.check(caller, Operation.NET_LISTEN, null, port);
     if (denial != null) {
       throw denial;
+    }
+  }
+
+  /** Helper for network.outbound operations with host/port. */
+  private static void checkNetworkOutbound(
+      PolicyEnforcer enforcer, CallerContext caller, String host, int port) {
+    SecurityException denial = enforcer.check(caller, Operation.NET_CONNECT, host, port);
+    if (denial != null) {
+      throw denial;
+    }
+  }
+
+  @Nested
+  @DisplayName("HOST_PORT category operations (network.outbound with host/port filtering)")
+  class HostPortOperationTest {
+
+    @Test
+    @DisplayName(
+        "allows network.outbound when entitled with no restrictions (backwards compatible)")
+    void allowsNetworkOutboundAnyHostPort() {
+      Entitlement entitlement =
+          new Entitlement(SubjectPattern.module(), CapabilityGrant.of("network.outbound"));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      assertThatCode(
+              () -> checkNetworkOutbound(enforcer, caller("com.example.app"), "example.com", 80))
+          .doesNotThrowAnyException();
+      assertThatCode(
+              () ->
+                  checkNetworkOutbound(enforcer, caller("com.example.app"), "api.example.com", 443))
+          .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("denies network.outbound when not entitled")
+    void deniesNetworkOutbound() {
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of());
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      assertThatThrownBy(
+              () -> checkNetworkOutbound(enforcer, caller("com.example.app"), "example.com", 80))
+          .isInstanceOf(SecurityException.class)
+          .hasMessageContaining("network.outbound");
+    }
+
+    @Test
+    @DisplayName("allows network.outbound with host pattern only")
+    void allowsNetworkOutboundHostPatternOnly() {
+      Entitlement entitlement =
+          new Entitlement(
+              SubjectPattern.module(),
+              CapabilityGrant.of(
+                  "network.outbound", List.of(new CapabilityArgument.StringArg("*.example.com"))));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      // Matching host allowed (any port)
+      assertThatCode(
+              () ->
+                  checkNetworkOutbound(enforcer, caller("com.example.app"), "api.example.com", 80))
+          .doesNotThrowAnyException();
+      assertThatCode(
+              () ->
+                  checkNetworkOutbound(enforcer, caller("com.example.app"), "api.example.com", 443))
+          .doesNotThrowAnyException();
+
+      // Non-matching host denied
+      assertThatThrownBy(
+              () -> checkNetworkOutbound(enforcer, caller("com.example.app"), "other.com", 80))
+          .isInstanceOf(SecurityException.class);
+    }
+
+    @Test
+    @DisplayName("allows network.outbound with specific port")
+    void allowsNetworkOutboundSpecificPort() {
+      Entitlement entitlement =
+          new Entitlement(
+              SubjectPattern.module(),
+              CapabilityGrant.of(
+                  "network.outbound",
+                  List.of(
+                      new CapabilityArgument.StringArg("*"),
+                      new CapabilityArgument.IntegerArg(443))));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      // Port 443 to any host allowed
+      assertThatCode(
+              () -> checkNetworkOutbound(enforcer, caller("com.example.app"), "example.com", 443))
+          .doesNotThrowAnyException();
+
+      // Other ports denied
+      assertThatThrownBy(
+              () -> checkNetworkOutbound(enforcer, caller("com.example.app"), "example.com", 80))
+          .isInstanceOf(SecurityException.class);
+    }
+
+    @Test
+    @DisplayName("allows network.outbound with port range")
+    void allowsNetworkOutboundPortRange() {
+      Entitlement entitlement =
+          new Entitlement(
+              SubjectPattern.module(),
+              CapabilityGrant.of(
+                  "network.outbound",
+                  List.of(
+                      new CapabilityArgument.StringArg("*"),
+                      new CapabilityArgument.StringArg("80-443"))));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      // Ports in range allowed
+      assertThatCode(
+              () -> checkNetworkOutbound(enforcer, caller("com.example.app"), "example.com", 80))
+          .doesNotThrowAnyException();
+      assertThatCode(
+              () -> checkNetworkOutbound(enforcer, caller("com.example.app"), "example.com", 200))
+          .doesNotThrowAnyException();
+      assertThatCode(
+              () -> checkNetworkOutbound(enforcer, caller("com.example.app"), "example.com", 443))
+          .doesNotThrowAnyException();
+
+      // Port outside range denied
+      assertThatThrownBy(
+              () -> checkNetworkOutbound(enforcer, caller("com.example.app"), "example.com", 444))
+          .isInstanceOf(SecurityException.class);
+    }
+
+    @Test
+    @DisplayName("allows network.outbound with host and port combined")
+    void allowsNetworkOutboundHostAndPort() {
+      Entitlement entitlement =
+          new Entitlement(
+              SubjectPattern.module(),
+              CapabilityGrant.of(
+                  "network.outbound",
+                  List.of(
+                      new CapabilityArgument.StringArg("*.example.com"),
+                      new CapabilityArgument.IntegerArg(443))));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      // Both host and port must match
+      assertThatCode(
+              () ->
+                  checkNetworkOutbound(enforcer, caller("com.example.app"), "api.example.com", 443))
+          .doesNotThrowAnyException();
+
+      // Wrong port denied
+      assertThatThrownBy(
+              () ->
+                  checkNetworkOutbound(enforcer, caller("com.example.app"), "api.example.com", 80))
+          .isInstanceOf(SecurityException.class);
+
+      // Wrong host denied
+      assertThatThrownBy(
+              () -> checkNetworkOutbound(enforcer, caller("com.example.app"), "other.com", 443))
+          .isInstanceOf(SecurityException.class);
+    }
+
+    @Test
+    @DisplayName("denies port 0 for network.outbound (invalid destination)")
+    void deniesPort0ForNetworkOutbound() {
+      Entitlement entitlement =
+          new Entitlement(SubjectPattern.module(), CapabilityGrant.of("network.outbound"));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      // Port 0 is always denied for outbound connections
+      assertThatThrownBy(
+              () -> checkNetworkOutbound(enforcer, caller("com.example.app"), "example.com", 0))
+          .isInstanceOf(SecurityException.class);
+    }
+
+    @Test
+    @DisplayName("multiple entitlements - any match allows")
+    void multipleEntitlementsAnyMatchAllows() {
+      Entitlement e1 =
+          new Entitlement(
+              SubjectPattern.module(),
+              CapabilityGrant.of(
+                  "network.outbound",
+                  List.of(
+                      new CapabilityArgument.StringArg("*.example.com"),
+                      new CapabilityArgument.IntegerArg(443))));
+      Entitlement e2 =
+          new Entitlement(
+              SubjectPattern.module(),
+              CapabilityGrant.of(
+                  "network.outbound",
+                  List.of(
+                      new CapabilityArgument.StringArg("*.internal.net"),
+                      new CapabilityArgument.StringArg("8080-8090"))));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(e1, e2));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      // First entitlement matches
+      assertThatCode(
+              () ->
+                  checkNetworkOutbound(enforcer, caller("com.example.app"), "api.example.com", 443))
+          .doesNotThrowAnyException();
+
+      // Second entitlement matches
+      assertThatCode(
+              () ->
+                  checkNetworkOutbound(
+                      enforcer, caller("com.example.app"), "server.internal.net", 8085))
+          .doesNotThrowAnyException();
+
+      // Neither matches
+      assertThatThrownBy(
+              () -> checkNetworkOutbound(enforcer, caller("com.example.app"), "other.com", 80))
+          .isInstanceOf(SecurityException.class);
+    }
+
+    @Test
+    @DisplayName("host pattern ** matches multiple subdomains")
+    void doubleStarHostPattern() {
+      Entitlement entitlement =
+          new Entitlement(
+              SubjectPattern.module(),
+              CapabilityGrant.of(
+                  "network.outbound", List.of(new CapabilityArgument.StringArg("**.example.com"))));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      // Single subdomain matches
+      assertThatCode(
+              () ->
+                  checkNetworkOutbound(enforcer, caller("com.example.app"), "api.example.com", 443))
+          .doesNotThrowAnyException();
+
+      // Multiple subdomains match
+      assertThatCode(
+              () ->
+                  checkNetworkOutbound(
+                      enforcer, caller("com.example.app"), "a.b.c.example.com", 443))
+          .doesNotThrowAnyException();
+
+      // Base domain does NOT match (** requires at least one segment)
+      assertThatThrownBy(
+              () -> checkNetworkOutbound(enforcer, caller("com.example.app"), "example.com", 443))
+          .isInstanceOf(SecurityException.class);
+    }
+
+    @Test
+    @DisplayName("host matching is case insensitive")
+    void hostMatchingCaseInsensitive() {
+      Entitlement entitlement =
+          new Entitlement(
+              SubjectPattern.module(),
+              CapabilityGrant.of(
+                  "network.outbound", List.of(new CapabilityArgument.StringArg("*.example.com"))));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      // Mixed case matches
+      assertThatCode(
+              () ->
+                  checkNetworkOutbound(enforcer, caller("com.example.app"), "API.Example.COM", 443))
+          .doesNotThrowAnyException();
+    }
+  }
+
+  @Nested
+  @DisplayName("PORT category with ranges (network.listen)")
+  class PortRangeOperationTest {
+
+    @Test
+    @DisplayName("allows network.listen with port range")
+    void allowsNetworkListenPortRange() {
+      Entitlement entitlement =
+          new Entitlement(
+              SubjectPattern.module(),
+              CapabilityGrant.of(
+                  "network.listen", List.of(new CapabilityArgument.StringArg("8080-8090"))));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      // Ports in range allowed
+      assertThatCode(() -> checkNetworkListen(enforcer, caller("com.example.app"), 8080))
+          .doesNotThrowAnyException();
+      assertThatCode(() -> checkNetworkListen(enforcer, caller("com.example.app"), 8085))
+          .doesNotThrowAnyException();
+      assertThatCode(() -> checkNetworkListen(enforcer, caller("com.example.app"), 8090))
+          .doesNotThrowAnyException();
+
+      // Port outside range denied
+      assertThatThrownBy(() -> checkNetworkListen(enforcer, caller("com.example.app"), 8091))
+          .isInstanceOf(SecurityException.class);
+    }
+
+    @Test
+    @DisplayName("allows port 0 (ephemeral) when entitled to any port")
+    void allowsPort0WhenAnyPort() {
+      Entitlement entitlement =
+          new Entitlement(SubjectPattern.module(), CapabilityGrant.of("network.listen"));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      // Port 0 allowed with no restriction
+      assertThatCode(() -> checkNetworkListen(enforcer, caller("com.example.app"), 0))
+          .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("denies port 0 (ephemeral) when entitled to specific port")
+    void deniesPort0WhenSpecificPort() {
+      Entitlement entitlement =
+          new Entitlement(
+              SubjectPattern.module(),
+              CapabilityGrant.of(
+                  "network.listen", List.of(new CapabilityArgument.IntegerArg(8080))));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      // Port 0 denied when only specific port is allowed
+      assertThatThrownBy(() -> checkNetworkListen(enforcer, caller("com.example.app"), 0))
+          .isInstanceOf(SecurityException.class);
+    }
+
+    @Test
+    @DisplayName("denies port 0 when entitled to range not containing 0")
+    void deniesPort0WhenRangeDoesNotContain0() {
+      Entitlement entitlement =
+          new Entitlement(
+              SubjectPattern.module(),
+              CapabilityGrant.of(
+                  "network.listen", List.of(new CapabilityArgument.StringArg("8080-8090"))));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      // Port 0 denied when range doesn't include 0
+      assertThatThrownBy(() -> checkNetworkListen(enforcer, caller("com.example.app"), 0))
+          .isInstanceOf(SecurityException.class);
+    }
+
+    @Test
+    @DisplayName("allows port 0 when entitled to range containing 0")
+    void allowsPort0WhenRangeContains0() {
+      Entitlement entitlement =
+          new Entitlement(
+              SubjectPattern.module(),
+              CapabilityGrant.of(
+                  "network.listen", List.of(new CapabilityArgument.StringArg("0-1024"))));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      // Port 0 allowed when range includes 0
+      assertThatCode(() -> checkNetworkListen(enforcer, caller("com.example.app"), 0))
+          .doesNotThrowAnyException();
     }
   }
 }

--- a/agent/src/test/java/org/jguard/agent/PortRangeTest.java
+++ b/agent/src/test/java/org/jguard/agent/PortRangeTest.java
@@ -1,0 +1,235 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The jGuard Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.jguard.agent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link PortRange}. */
+class PortRangeTest {
+
+  @Nested
+  @DisplayName("parse()")
+  class ParseTests {
+
+    @Test
+    @DisplayName("parses single port")
+    void parsesSinglePort() {
+      PortRange range = PortRange.parse("443");
+      assertThat(range.start()).isEqualTo(443);
+      assertThat(range.end()).isEqualTo(443);
+    }
+
+    @Test
+    @DisplayName("parses port range")
+    void parsesRange() {
+      PortRange range = PortRange.parse("80-443");
+      assertThat(range.start()).isEqualTo(80);
+      assertThat(range.end()).isEqualTo(443);
+    }
+
+    @Test
+    @DisplayName("parses port 0")
+    void parsesPortZero() {
+      PortRange range = PortRange.parse("0");
+      assertThat(range.start()).isEqualTo(0);
+      assertThat(range.end()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("parses full range")
+    void parsesFullRange() {
+      PortRange range = PortRange.parse("0-65535");
+      assertThat(range.start()).isEqualTo(0);
+      assertThat(range.end()).isEqualTo(65535);
+    }
+
+    @Test
+    @DisplayName("rejects range with spaces")
+    void rejectsRangeWithSpaces() {
+      assertThatThrownBy(() -> PortRange.parse("80 - 443"))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Invalid port number");
+    }
+
+    @Test
+    @DisplayName("rejects leading whitespace")
+    void rejectsLeadingWhitespace() {
+      assertThatThrownBy(() -> PortRange.parse(" 443"))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("whitespace");
+    }
+
+    @Test
+    @DisplayName("rejects trailing whitespace")
+    void rejectsTrailingWhitespace() {
+      assertThatThrownBy(() -> PortRange.parse("443 "))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("whitespace");
+    }
+
+    @Test
+    @DisplayName("rejects reversed range")
+    void rejectsReversedRange() {
+      assertThatThrownBy(() -> PortRange.parse("443-80"))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("cannot be greater than end");
+    }
+
+    @Test
+    @DisplayName("rejects negative port")
+    void rejectsNegativePort() {
+      assertThatThrownBy(() -> PortRange.parse("-1")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("rejects port out of range")
+    void rejectsOutOfRange() {
+      assertThatThrownBy(() -> PortRange.parse("70000"))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("out of range");
+    }
+
+    @Test
+    @DisplayName("rejects invalid format - letters")
+    void rejectsLetters() {
+      assertThatThrownBy(() -> PortRange.parse("abc"))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Invalid port number");
+    }
+
+    @Test
+    @DisplayName("rejects invalid format - trailing dash")
+    void rejectsTrailingDash() {
+      assertThatThrownBy(() -> PortRange.parse("80-"))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("ends with dash");
+    }
+
+    @Test
+    @DisplayName("rejects invalid format - leading dash for range")
+    void rejectsLeadingDashRange() {
+      assertThatThrownBy(() -> PortRange.parse("-443"))
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("rejects null")
+    void rejectsNull() {
+      assertThatThrownBy(() -> PortRange.parse(null))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("null or empty");
+    }
+
+    @Test
+    @DisplayName("rejects empty string")
+    void rejectsEmpty() {
+      assertThatThrownBy(() -> PortRange.parse(""))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("null or empty");
+    }
+  }
+
+  @Nested
+  @DisplayName("single()")
+  class SingleTests {
+
+    @Test
+    @DisplayName("creates range for single port")
+    void createsSinglePort() {
+      PortRange range = PortRange.single(8080);
+      assertThat(range.start()).isEqualTo(8080);
+      assertThat(range.end()).isEqualTo(8080);
+    }
+
+    @Test
+    @DisplayName("rejects invalid port")
+    void rejectsInvalidPort() {
+      assertThatThrownBy(() -> PortRange.single(-1)).isInstanceOf(IllegalArgumentException.class);
+      assertThatThrownBy(() -> PortRange.single(70000))
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("any()")
+  class AnyTests {
+
+    @Test
+    @DisplayName("covers full port range")
+    void coversFullRange() {
+      PortRange range = PortRange.any();
+      assertThat(range.start()).isEqualTo(0);
+      assertThat(range.end()).isEqualTo(65535);
+    }
+  }
+
+  @Nested
+  @DisplayName("contains()")
+  class ContainsTests {
+
+    @Test
+    @DisplayName("returns true for port in range")
+    void containsInRange() {
+      PortRange range = PortRange.parse("80-443");
+      assertThat(range.contains(80)).isTrue();
+      assertThat(range.contains(200)).isTrue();
+      assertThat(range.contains(443)).isTrue();
+    }
+
+    @Test
+    @DisplayName("returns false for port out of range")
+    void doesNotContainOutOfRange() {
+      PortRange range = PortRange.parse("80-443");
+      assertThat(range.contains(79)).isFalse();
+      assertThat(range.contains(444)).isFalse();
+      assertThat(range.contains(0)).isFalse();
+      assertThat(range.contains(65535)).isFalse();
+    }
+
+    @Test
+    @DisplayName("any range contains all ports")
+    void anyContainsAll() {
+      PortRange range = PortRange.any();
+      assertThat(range.contains(0)).isTrue();
+      assertThat(range.contains(80)).isTrue();
+      assertThat(range.contains(443)).isTrue();
+      assertThat(range.contains(65535)).isTrue();
+    }
+
+    @Test
+    @DisplayName("single port range only contains that port")
+    void singleContainsOnlyOne() {
+      PortRange range = PortRange.single(8080);
+      assertThat(range.contains(8080)).isTrue();
+      assertThat(range.contains(8079)).isFalse();
+      assertThat(range.contains(8081)).isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("toString()")
+  class ToStringTests {
+
+    @Test
+    @DisplayName("formats single port")
+    void formatsSingle() {
+      assertThat(PortRange.single(443).toString()).isEqualTo("443");
+    }
+
+    @Test
+    @DisplayName("formats range")
+    void formatsRange() {
+      assertThat(PortRange.parse("80-443").toString()).isEqualTo("80-443");
+    }
+  }
+}

--- a/docs/spec/jguard-policy-descriptor.md
+++ b/docs/spec/jguard-policy-descriptor.md
@@ -222,14 +222,14 @@ Each capability has a fixed signature that determines:
 
 The following capabilities are defined in jGuard version 1:
 
-| Capability         | Signature                | Description                              |
-| ------------------ | ------------------------ | ---------------------------------------- |
-| `fs.read`          | `(root, glob)`           | Read files matching glob under root      |
-| `fs.write`         | `(root, glob)`           | Write files matching glob under root     |
-| `network.outbound` | (no arguments)           | Open outbound network connections        |
-| `network.listen`   | `(port?)`                | Bind server sockets (optional port)      |
-| `threads.create`   | (no arguments)           | Create new threads                       |
-| `native.load`      | `(pattern?)`             | Load native libraries (optional pattern) |
+| Capability         | Signature                    | Description                              |
+| ------------------ | ---------------------------- | ---------------------------------------- |
+| `fs.read`          | `(root, glob)`               | Read files matching glob under root      |
+| `fs.write`         | `(root, glob)`               | Write files matching glob under root     |
+| `network.outbound` | `(hostPattern?, portSpec?)`  | Open outbound network connections        |
+| `network.listen`   | `(portSpec?)`                | Bind server sockets (optional port/range)|
+| `threads.create`   | (no arguments)               | Create new threads                       |
+| `native.load`      | `(pattern?)`                 | Load native libraries (optional pattern) |
 
 #### Argument details
 
@@ -238,9 +238,38 @@ The following capabilities are defined in jGuard version 1:
 * `root` — base directory path (string)
 * `glob` — glob pattern for matching files (string, e.g., `"**/*"`, `"*.txt"`)
 
-**`network.listen(port?)`**
+**`network.outbound(hostPattern?, portSpec?)`**
 
-* `port` — optional port number (integer); if omitted, allows binding to any port
+* `hostPattern` — optional host glob pattern (string); if omitted, allows any host
+* `portSpec` — optional port or port range (integer or string); if omitted, allows any port
+
+Host pattern syntax:
+* `*` — matches exactly one DNS segment (e.g., `*.example.com` matches `api.example.com` but not `a.b.example.com`)
+* `**` — matches one or more DNS segments (e.g., `**.example.com` matches `api.example.com` and `a.b.c.example.com`)
+* Literal segments for exact matching
+
+Port spec can be:
+* Integer: `443` — specific port
+* String range: `"80-443"` — port range (inclusive)
+
+Examples:
+```
+entitle module to network.outbound;                           // Any host, any port
+entitle module to network.outbound("*.example.com");          // Any port to matching hosts
+entitle module to network.outbound("*", 443);                 // Port 443 to any host
+entitle module to network.outbound("*.example.com", "80-443"); // Port range to matching hosts
+```
+
+**`network.listen(portSpec?)`**
+
+* `portSpec` — optional port or port range (integer or string); if omitted, allows binding to any port
+
+Examples:
+```
+entitle module to network.listen;           // Any port
+entitle module to network.listen(8080);     // Specific port
+entitle module to network.listen("8080-8090"); // Port range
+```
 
 **`native.load(pattern?)`**
 

--- a/policy/src/main/java/org/jguard/policy/validation/PolicyValidator.java
+++ b/policy/src/main/java/org/jguard/policy/validation/PolicyValidator.java
@@ -44,8 +44,9 @@ public final class PolicyValidator {
       Map.of(
           "fs.read", new CapabilitySignature(2, 2, List.of(ArgType.STRING, ArgType.STRING)),
           "fs.write", new CapabilitySignature(2, 2, List.of(ArgType.STRING, ArgType.STRING)),
-          "network.outbound", new CapabilitySignature(0, 0, List.of()),
-          "network.listen", new CapabilitySignature(0, 1, List.of(ArgType.INTEGER)),
+          "network.outbound",
+              new CapabilitySignature(0, 2, List.of(ArgType.STRING, ArgType.STRING_OR_INTEGER)),
+          "network.listen", new CapabilitySignature(0, 1, List.of(ArgType.STRING_OR_INTEGER)),
           "threads.create", new CapabilitySignature(0, 0, List.of()),
           "native.load", new CapabilitySignature(0, 1, List.of(ArgType.STRING)));
 
@@ -182,6 +183,124 @@ public final class PolicyValidator {
       ArgType expectedType = signature.argTypes().get(i);
       validateArgument(arg, expectedType, name, i);
     }
+
+    // Semantic validation per capability
+    validateCapabilitySemantics(name, args, location);
+  }
+
+  private void validateCapabilitySemantics(
+      String name, List<Argument> args, SourceLocation location) {
+    switch (name) {
+      case "network.outbound" -> validateNetworkOutbound(args, location);
+      case "network.listen" -> validateNetworkListen(args, location);
+      default -> {
+        // Other capabilities don't need semantic validation yet
+      }
+    }
+  }
+
+  private void validateNetworkOutbound(List<Argument> args, SourceLocation location) {
+    if (args.isEmpty()) {
+      return; // OK: any host, any port
+    }
+
+    // First arg must be host pattern (string)
+    Argument firstArg = args.get(0);
+    if (firstArg instanceof Argument.StringLiteral s) {
+      validateHostPattern(s.value(), location);
+    } else if (firstArg instanceof Argument.Identifier id) {
+      validateHostPattern(id.value(), location);
+    }
+    // IntegerLiteral for first arg is a type error already caught above
+
+    // Second arg (if present) must be port spec
+    if (args.size() >= 2) {
+      validatePortSpec(args.get(1), location);
+    }
+  }
+
+  private void validateNetworkListen(List<Argument> args, SourceLocation location) {
+    if (args.isEmpty()) {
+      return; // OK: any port
+    }
+    validatePortSpec(args.get(0), location);
+  }
+
+  private void validateHostPattern(String pattern, SourceLocation location) {
+    if (pattern == null || pattern.isEmpty()) {
+      error("Host pattern cannot be empty", location);
+      return;
+    }
+
+    // Reject trailing/leading dots in policy
+    if (pattern.startsWith(".") || pattern.endsWith(".")) {
+      error("Invalid host pattern (leading/trailing dot): " + pattern, location);
+      return;
+    }
+
+    // Validate segment-by-segment
+    String[] segments = pattern.split("\\.");
+    for (int i = 0; i < segments.length; i++) {
+      String seg = segments[i];
+
+      if (seg.isEmpty()) {
+        error("Invalid host pattern (empty segment): " + pattern, location);
+        return;
+      }
+
+      // Each segment must be: "*", "**", or literal with no wildcards
+      if (seg.contains("*")) {
+        if (!seg.equals("*") && !seg.equals("**")) {
+          error("Partial-label wildcards not supported: " + pattern, location);
+          return;
+        }
+        // Reject consecutive ** segments
+        if (seg.equals("**") && i > 0 && segments[i - 1].equals("**")) {
+          error("Consecutive ** not allowed: " + pattern, location);
+          return;
+        }
+      }
+    }
+  }
+
+  private void validatePortSpec(Argument arg, SourceLocation location) {
+    if (arg instanceof Argument.IntegerLiteral intArg) {
+      long port = intArg.value();
+      if (port < 0 || port > 65535) {
+        error("Port out of range (0-65535): " + port, location);
+      }
+    } else if (arg instanceof Argument.StringLiteral strArg) {
+      String spec = strArg.value().trim();
+      if (!spec.matches("\\d+(-\\d+)?")) {
+        error("Invalid port spec (expected 'port' or 'start-end'): " + spec, location);
+        return;
+      }
+      // Parse and validate range
+      int dashIndex = spec.indexOf('-');
+      if (dashIndex == -1) {
+        // Single port
+        long port = Long.parseLong(spec);
+        if (port < 0 || port > 65535) {
+          error("Port out of range (0-65535): " + port, location);
+        }
+      } else {
+        // Range
+        long start = Long.parseLong(spec.substring(0, dashIndex));
+        long end = Long.parseLong(spec.substring(dashIndex + 1));
+        if (start < 0 || start > 65535) {
+          error("Start port out of range (0-65535): " + start, location);
+        }
+        if (end < 0 || end > 65535) {
+          error("End port out of range (0-65535): " + end, location);
+        }
+        if (start > end) {
+          error("Port range start cannot be greater than end: " + spec, location);
+        }
+      }
+    } else if (arg instanceof Argument.Identifier id) {
+      // Identifiers for port specs are allowed (e.g., named constants)
+      // We can't validate the value at compile time
+    }
   }
 
   private void validateArgument(
@@ -191,6 +310,10 @@ public final class PolicyValidator {
           case STRING ->
               arg instanceof Argument.StringLiteral || arg instanceof Argument.Identifier;
           case INTEGER -> arg instanceof Argument.IntegerLiteral;
+          case STRING_OR_INTEGER ->
+              arg instanceof Argument.StringLiteral
+                  || arg instanceof Argument.Identifier
+                  || arg instanceof Argument.IntegerLiteral;
         };
 
     if (!valid) {
@@ -200,13 +323,17 @@ public final class PolicyValidator {
             case Argument.StringLiteral s -> "string";
             case Argument.IntegerLiteral n -> "integer";
           };
+      String expectedDescription =
+          expectedType == ArgType.STRING_OR_INTEGER
+              ? "string or integer"
+              : expectedType.name().toLowerCase();
       error(
           "Capability '"
               + capabilityName
               + "' argument "
               + (index + 1)
               + " must be "
-              + expectedType.name().toLowerCase()
+              + expectedDescription
               + ", got "
               + actualType,
           arg.location());
@@ -288,7 +415,8 @@ public final class PolicyValidator {
 
   private enum ArgType {
     STRING,
-    INTEGER
+    INTEGER,
+    STRING_OR_INTEGER
   }
 
   /**

--- a/policy/src/test/java/org/jguard/policy/compiler/ValidationTest.java
+++ b/policy/src/test/java/org/jguard/policy/compiler/ValidationTest.java
@@ -46,17 +46,34 @@ class ValidationTest {
 
   @Test
   void rejectsWrongArgumentType() {
+    // fs.read requires strings, not integers
     String source =
         """
             security module com.example.app {
-                entitle module to network.listen("not-a-number");
+                entitle module to fs.read(123, "*.txt");
             }
             """;
 
     PolicyCompiler.CompileResult result = PolicyCompiler.compileSource(source, "test.jguard");
 
     assertThat(result.hasErrors()).isTrue();
-    assertThat(result.diagnostics()).anyMatch(d -> d.message().contains("must be integer"));
+    assertThat(result.diagnostics()).anyMatch(d -> d.message().contains("must be string"));
+  }
+
+  @Test
+  void rejectsInvalidPortSpec() {
+    // network.listen rejects invalid port specs
+    String source =
+        """
+            security module com.example.app {
+                entitle module to network.listen("not-a-port");
+            }
+            """;
+
+    PolicyCompiler.CompileResult result = PolicyCompiler.compileSource(source, "test.jguard");
+
+    assertThat(result.hasErrors()).isTrue();
+    assertThat(result.diagnostics()).anyMatch(d -> d.message().contains("Invalid port spec"));
   }
 
   @Test

--- a/policy/src/test/java/org/jguard/policy/validation/PolicyValidatorTest.java
+++ b/policy/src/test/java/org/jguard/policy/validation/PolicyValidatorTest.java
@@ -206,9 +206,8 @@ class PolicyValidatorTest {
 
     @Test
     void rejectsCapabilityWithExtraArguments() {
-      // network.outbound takes no arguments
-      EntitlementDeclaration entitlement =
-          moduleEntitlement("network.outbound", stringArg("extra"));
+      // threads.create takes no arguments
+      EntitlementDeclaration entitlement = moduleEntitlement("threads.create", stringArg("extra"));
       PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
 
       PolicyValidator.ValidationResult result = validate(ast);
@@ -219,15 +218,15 @@ class PolicyValidatorTest {
 
     @Test
     void rejectsCapabilityWithWrongArgumentType() {
-      // network.listen requires integer, not string
+      // fs.read requires strings, not integers
       EntitlementDeclaration entitlement =
-          moduleEntitlement("network.listen", stringArg("not-a-port"));
+          moduleEntitlement("fs.read", intArg(123), stringArg("*.json"));
       PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
 
       PolicyValidator.ValidationResult result = validate(ast);
 
       assertThat(result.hasErrors()).isTrue();
-      assertThat(result.diagnostics()).anyMatch(d -> d.message().contains("must be integer"));
+      assertThat(result.diagnostics()).anyMatch(d -> d.message().contains("must be string"));
     }
 
     @Test
@@ -322,5 +321,234 @@ class PolicyValidatorTest {
 
   private Argument identifierArg(String value) {
     return new Argument.Identifier(value, LOC);
+  }
+
+  @Nested
+  class NetworkOutboundSemanticValidationTest {
+
+    @Test
+    void acceptsNetworkOutboundWithNoArgs() {
+      EntitlementDeclaration entitlement = moduleEntitlement("network.outbound");
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+      assertThat(result.isValid()).isTrue();
+    }
+
+    @Test
+    void acceptsNetworkOutboundWithHostOnly() {
+      EntitlementDeclaration entitlement =
+          moduleEntitlement("network.outbound", stringArg("*.example.com"));
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+      assertThat(result.isValid()).isTrue();
+    }
+
+    @Test
+    void acceptsNetworkOutboundWithHostAndPort() {
+      EntitlementDeclaration entitlement =
+          moduleEntitlement("network.outbound", stringArg("*.example.com"), intArg(443));
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+      assertThat(result.isValid()).isTrue();
+    }
+
+    @Test
+    void acceptsNetworkOutboundWithHostAndPortRange() {
+      EntitlementDeclaration entitlement =
+          moduleEntitlement("network.outbound", stringArg("*.example.com"), stringArg("80-443"));
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+      assertThat(result.isValid()).isTrue();
+    }
+
+    @Test
+    void acceptsDoubleStarHostPattern() {
+      EntitlementDeclaration entitlement =
+          moduleEntitlement("network.outbound", stringArg("**.example.com"));
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+      assertThat(result.isValid()).isTrue();
+    }
+
+    @Test
+    void acceptsStarOnlyPattern() {
+      EntitlementDeclaration entitlement = moduleEntitlement("network.outbound", stringArg("*"));
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+      assertThat(result.isValid()).isTrue();
+    }
+
+    @Test
+    void rejectsPartialLabelWildcard() {
+      EntitlementDeclaration entitlement =
+          moduleEntitlement("network.outbound", stringArg("api*-blue.example.com"));
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+
+      assertThat(result.hasErrors()).isTrue();
+      assertThat(result.diagnostics())
+          .anyMatch(d -> d.message().contains("Partial-label wildcards not supported"));
+    }
+
+    @Test
+    void rejectsEmptySegmentInHostPattern() {
+      EntitlementDeclaration entitlement =
+          moduleEntitlement("network.outbound", stringArg("api..example.com"));
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+
+      assertThat(result.hasErrors()).isTrue();
+      assertThat(result.diagnostics()).anyMatch(d -> d.message().contains("empty segment"));
+    }
+
+    @Test
+    void rejectsLeadingDotInHostPattern() {
+      EntitlementDeclaration entitlement =
+          moduleEntitlement("network.outbound", stringArg(".example.com"));
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+
+      assertThat(result.hasErrors()).isTrue();
+      assertThat(result.diagnostics()).anyMatch(d -> d.message().contains("leading/trailing dot"));
+    }
+
+    @Test
+    void rejectsTrailingDotInHostPattern() {
+      EntitlementDeclaration entitlement =
+          moduleEntitlement("network.outbound", stringArg("example.com."));
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+
+      assertThat(result.hasErrors()).isTrue();
+      assertThat(result.diagnostics()).anyMatch(d -> d.message().contains("leading/trailing dot"));
+    }
+
+    @Test
+    void rejectsConsecutiveDoubleStars() {
+      EntitlementDeclaration entitlement =
+          moduleEntitlement("network.outbound", stringArg("**.**.example.com"));
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+
+      assertThat(result.hasErrors()).isTrue();
+      assertThat(result.diagnostics())
+          .anyMatch(d -> d.message().contains("Consecutive ** not allowed"));
+    }
+
+    @Test
+    void rejectsReversedPortRange() {
+      EntitlementDeclaration entitlement =
+          moduleEntitlement("network.outbound", stringArg("*"), stringArg("443-80"));
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+
+      assertThat(result.hasErrors()).isTrue();
+      assertThat(result.diagnostics())
+          .anyMatch(d -> d.message().contains("start cannot be greater than end"));
+    }
+
+    @Test
+    void rejectsPortOutOfRange() {
+      EntitlementDeclaration entitlement =
+          moduleEntitlement("network.outbound", stringArg("*"), intArg(70000));
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+
+      assertThat(result.hasErrors()).isTrue();
+      assertThat(result.diagnostics()).anyMatch(d -> d.message().contains("out of range"));
+    }
+
+    @Test
+    void rejectsInvalidPortSpecFormat() {
+      EntitlementDeclaration entitlement =
+          moduleEntitlement("network.outbound", stringArg("*"), stringArg("abc"));
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+
+      assertThat(result.hasErrors()).isTrue();
+      assertThat(result.diagnostics()).anyMatch(d -> d.message().contains("Invalid port spec"));
+    }
+  }
+
+  @Nested
+  class NetworkListenSemanticValidationTest {
+
+    @Test
+    void acceptsNetworkListenWithNoArgs() {
+      EntitlementDeclaration entitlement = moduleEntitlement("network.listen");
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+      assertThat(result.isValid()).isTrue();
+    }
+
+    @Test
+    void acceptsNetworkListenWithIntegerPort() {
+      EntitlementDeclaration entitlement = moduleEntitlement("network.listen", intArg(8080));
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+      assertThat(result.isValid()).isTrue();
+    }
+
+    @Test
+    void acceptsNetworkListenWithPortRange() {
+      EntitlementDeclaration entitlement =
+          moduleEntitlement("network.listen", stringArg("8080-8090"));
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+      assertThat(result.isValid()).isTrue();
+    }
+
+    @Test
+    void rejectsNetworkListenWithInvalidPortString() {
+      EntitlementDeclaration entitlement =
+          moduleEntitlement("network.listen", stringArg("not-a-port"));
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+
+      assertThat(result.hasErrors()).isTrue();
+      assertThat(result.diagnostics()).anyMatch(d -> d.message().contains("Invalid port spec"));
+    }
+
+    @Test
+    void rejectsNetworkListenWithReversedRange() {
+      EntitlementDeclaration entitlement =
+          moduleEntitlement("network.listen", stringArg("9000-8000"));
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+
+      assertThat(result.hasErrors()).isTrue();
+      assertThat(result.diagnostics())
+          .anyMatch(d -> d.message().contains("start cannot be greater than end"));
+    }
+
+    @Test
+    void rejectsNetworkListenWithPortOutOfRange() {
+      EntitlementDeclaration entitlement = moduleEntitlement("network.listen", intArg(70000));
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+
+      assertThat(result.hasErrors()).isTrue();
+      assertThat(result.diagnostics()).anyMatch(d -> d.message().contains("out of range"));
+    }
   }
 }

--- a/samples/sandbox-demo/README.md
+++ b/samples/sandbox-demo/README.md
@@ -87,10 +87,54 @@ jGuard enforces your policy transparently—if the code is entitled, it runs; if
 |------------|-------------|
 | `fs.read(root, glob)` | Read files matching glob under root |
 | `fs.write(root, glob)` | Write files matching glob under root |
-| `network.outbound` | Make outbound network connections |
-| `network.listen(port?)` | Listen on a port (optional port arg) |
+| `network.outbound(host?, port?)` | Make outbound connections (optional host pattern and port/range) |
+| `network.listen(port?)` | Listen on a port (optional port or range like `"8080-8090"`) |
 | `threads.create` | Create threads |
 | `native.load(pattern?)` | Load native libraries (optional pattern) |
+
+Host patterns: `*` matches one DNS segment, `**` matches one or more. Example: `*.example.com`
+
+### Host/Port Filtering Example
+
+The demo includes a `RestrictedNetworkClient` that demonstrates host/port filtering:
+
+```
+// Policy restricts this package to specific hosts and ports
+entitle org.jguard.samples.sandbox.net.restricted to network.outbound("*.example.com", "80-443");
+```
+
+When running with the agent:
+- `api.example.com:443` → **ALLOWED** (host matches `*.example.com`, port in range)
+- `evil.com:443` → **DENIED** (host doesn't match pattern)
+- `api.example.com:8080` → **DENIED** (port outside range 80-443)
+
+**Try it:**
+
+```bash
+# Without agent (all connections allowed)
+../../gradlew run
+
+# With agent (host/port filtering enforced)
+../../gradlew runWithAgent
+```
+
+You'll see output like:
+
+```
+[ENTITLED] network.outbound("*.example.com", "80-443")
+  Attempting to connect to api.example.com:443...
+  SUCCESS: Connection ALLOWED (host matches *.example.com, port in 80-443)
+
+[NOT ENTITLED] network.outbound to non-matching host
+  Attempting to connect to evil.com:443...
+  (Policy only allows *.example.com)
+  BLOCKED (expected): Host 'evil.com' doesn't match '*.example.com'
+
+[NOT ENTITLED] network.outbound to non-matching port
+  Attempting to connect to api.example.com:8080...
+  (Policy only allows ports 80-443)
+  BLOCKED (expected): Port 8080 not in range 80-443
+```
 
 ## What Gets Built
 
@@ -164,9 +208,12 @@ sandbox-demo/
     │   ├── module-info.jguard        # jGuard policy (lives next to module-info.java)
     │   └── org/jguard/samples/sandbox/
     │       ├── Main.java             # Demo runner
-    │       ├── net/NetworkClient.java          # Entitled to network.outbound
-    │       ├── worker/BackgroundWorker.java    # Entitled to threads.create
-    │       └── nativelib/NativeLoader.java     # Entitled to native.load
+    │       ├── net/
+    │       │   ├── NetworkClient.java             # Entitled to network.outbound (any host)
+    │       │   └── restricted/
+    │       │       └── RestrictedNetworkClient.java # Entitled to *.example.com:80-443 only
+    │       ├── worker/BackgroundWorker.java       # Entitled to threads.create
+    │       └── nativelib/NativeLoader.java        # Entitled to native.load
     └── test/java/
         └── org/jguard/samples/sandbox/
             └── EntitlementTest.java

--- a/samples/sandbox-demo/src/main/java/module-info.java
+++ b/samples/sandbox-demo/src/main/java/module-info.java
@@ -4,5 +4,6 @@ module org.jguard.samples.sandbox {
 
     exports org.jguard.samples.sandbox;
     exports org.jguard.samples.sandbox.net;
+    exports org.jguard.samples.sandbox.net.restricted;
     exports org.jguard.samples.sandbox.worker;
 }

--- a/samples/sandbox-demo/src/main/java/module-info.jguard
+++ b/samples/sandbox-demo/src/main/java/module-info.jguard
@@ -16,7 +16,12 @@ security module org.jguard.samples.sandbox {
     entitle module to fs.write("build/test-output", "**");
 
     // Grant network outbound to specific packages
+    // The .net package can connect to any host/port
     entitle org.jguard.samples.sandbox.net to network.outbound;
+
+    // The .net.restricted subpackage can ONLY connect to *.example.com on ports 80-443
+    // This demonstrates host glob pattern + port range filtering
+    entitle org.jguard.samples.sandbox.net.restricted to network.outbound("*.example.com", "80-443");
 
     // Grant network listen to specific packages
     entitle org.jguard.samples.sandbox.net to network.listen;

--- a/samples/sandbox-demo/src/main/java/org/jguard/samples/sandbox/Main.java
+++ b/samples/sandbox-demo/src/main/java/org/jguard/samples/sandbox/Main.java
@@ -21,6 +21,7 @@ import org.jguard.core.JGuard;
 import org.jguard.samples.sandbox.nativelib.NativeLoader;
 import org.jguard.samples.sandbox.net.NetworkClient;
 import org.jguard.samples.sandbox.net.NetworkServer;
+import org.jguard.samples.sandbox.net.restricted.RestrictedNetworkClient;
 import org.jguard.samples.sandbox.worker.BackgroundWorker;
 
 /**
@@ -111,24 +112,33 @@ public final class Main {
     // Test 12: Server socket from non-entitled package (NOT ENTITLED)
     demonstrateUnentitledNetworkListenAccess();
 
+    // Test 13: Host/port filtering - connection to allowed host (ENTITLED)
+    demonstrateHostPortFiltering_AllowedHost();
+
+    // Test 14: Host/port filtering - connection to denied host (NOT ENTITLED)
+    demonstrateHostPortFiltering_DeniedHost();
+
+    // Test 15: Host/port filtering - connection to denied port (NOT ENTITLED)
+    demonstrateHostPortFiltering_DeniedPort();
+
     // === THREAD TESTS ===
     System.out.println("--- THREAD TESTS ---");
     System.out.println();
 
-    // Test 13: Thread creation from entitled package (ENTITLED)
+    // Test 16: Thread creation from entitled package (ENTITLED)
     demonstrateEntitledThreadAccess();
 
-    // Test 14: Thread creation from non-entitled package (NOT ENTITLED)
+    // Test 17: Thread creation from non-entitled package (NOT ENTITLED)
     demonstrateUnentitledThreadAccess();
 
     // === NATIVE LIBRARY TESTS ===
     System.out.println("--- NATIVE LIBRARY TESTS ---");
     System.out.println();
 
-    // Test 15: Native library load from entitled package (ENTITLED)
+    // Test 18: Native library load from entitled package (ENTITLED)
     demonstrateEntitledNativeAccess();
 
-    // Test 16: Native library load from non-entitled package (NOT ENTITLED)
+    // Test 19: Native library load from non-entitled package (NOT ENTITLED)
     demonstrateUnentitledNativeAccess();
   }
 
@@ -443,6 +453,77 @@ public final class Main {
       System.out.println("  BLOCKED (expected): " + e.getMessage());
     } catch (IOException e) {
       System.out.println("  ERROR: " + e.getMessage());
+    }
+
+    System.out.println();
+  }
+
+  /**
+   * Demonstrates host/port filtering - connecting to an ALLOWED host.
+   *
+   * <p>The .net.restricted package is entitled to network.outbound("*.example.com", "80-443").
+   * Connecting to api.example.com:443 should be ALLOWED.
+   */
+  private static void demonstrateHostPortFiltering_AllowedHost() {
+    System.out.println("[ENTITLED] network.outbound(\"*.example.com\", \"80-443\")");
+    System.out.println("  Attempting to connect to api.example.com:443...");
+
+    RestrictedNetworkClient.ConnectionResult result =
+        RestrictedNetworkClient.tryConnect("api.example.com", 443);
+
+    if (result.allowed()) {
+      System.out.println("  SUCCESS: Connection ALLOWED (host matches *.example.com, port in 80-443)");
+      System.out.println("  Network result: " + result.message());
+    } else {
+      System.out.println("  BLOCKED (unexpected): " + result.message());
+    }
+
+    System.out.println();
+  }
+
+  /**
+   * Demonstrates host/port filtering - connecting to a DENIED host.
+   *
+   * <p>The .net.restricted package is entitled to network.outbound("*.example.com", "80-443").
+   * Connecting to evil.com:443 should be DENIED because the host doesn't match *.example.com.
+   */
+  private static void demonstrateHostPortFiltering_DeniedHost() {
+    System.out.println("[NOT ENTITLED] network.outbound to non-matching host");
+    System.out.println("  Attempting to connect to evil.com:443...");
+    System.out.println("  (Policy only allows *.example.com)");
+
+    RestrictedNetworkClient.ConnectionResult result =
+        RestrictedNetworkClient.tryConnect("evil.com", 443);
+
+    if (result.allowed()) {
+      System.out.println("  SUCCESS: Connection allowed (unexpected!)");
+      System.out.println("  (This should be BLOCKED when running with the agent!)");
+    } else {
+      System.out.println("  BLOCKED (expected): Host 'evil.com' doesn't match '*.example.com'");
+    }
+
+    System.out.println();
+  }
+
+  /**
+   * Demonstrates host/port filtering - connecting to a DENIED port.
+   *
+   * <p>The .net.restricted package is entitled to network.outbound("*.example.com", "80-443").
+   * Connecting to api.example.com:8080 should be DENIED because port 8080 is outside 80-443.
+   */
+  private static void demonstrateHostPortFiltering_DeniedPort() {
+    System.out.println("[NOT ENTITLED] network.outbound to non-matching port");
+    System.out.println("  Attempting to connect to api.example.com:8080...");
+    System.out.println("  (Policy only allows ports 80-443)");
+
+    RestrictedNetworkClient.ConnectionResult result =
+        RestrictedNetworkClient.tryConnect("api.example.com", 8080);
+
+    if (result.allowed()) {
+      System.out.println("  SUCCESS: Connection allowed (unexpected!)");
+      System.out.println("  (This should be BLOCKED when running with the agent!)");
+    } else {
+      System.out.println("  BLOCKED (expected): Port 8080 not in range 80-443");
     }
 
     System.out.println();

--- a/samples/sandbox-demo/src/main/java/org/jguard/samples/sandbox/net/restricted/RestrictedNetworkClient.java
+++ b/samples/sandbox-demo/src/main/java/org/jguard/samples/sandbox/net/restricted/RestrictedNetworkClient.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The jGuard Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.jguard.samples.sandbox.net.restricted;
+
+import java.io.IOException;
+import java.net.Socket;
+
+/**
+ * Network client with restricted host/port filtering.
+ *
+ * <p>This class is in the {@code org.jguard.samples.sandbox.net.restricted} package, which is
+ * granted limited {@code network.outbound("*.example.com", "80-443")} capability.
+ *
+ * <p>Connections to hosts matching {@code *.example.com} on ports 80-443 are allowed. All other
+ * connections are denied.
+ */
+public final class RestrictedNetworkClient {
+
+  private RestrictedNetworkClient() {}
+
+  /**
+   * Result of a connection attempt, distinguishing security denial from network failure.
+   */
+  public record ConnectionResult(boolean allowed, boolean connected, String message) {
+    public static ConnectionResult allowed(boolean connected) {
+      return new ConnectionResult(true, connected,
+          connected ? "Connection successful" : "Connection allowed but failed (network issue)");
+    }
+
+    public static ConnectionResult denied(String reason) {
+      return new ConnectionResult(false, false, "DENIED: " + reason);
+    }
+  }
+
+  /**
+   * Attempts to connect to the specified host and port.
+   *
+   * <p>This method is entitled to connect ONLY to:
+   * <ul>
+   *   <li>Hosts matching {@code *.example.com} (e.g., api.example.com, www.example.com)</li>
+   *   <li>Ports in the range 80-443</li>
+   * </ul>
+   *
+   * @param host the host to connect to
+   * @param port the port to connect to
+   * @return result indicating whether the connection was allowed and if it succeeded
+   */
+  public static ConnectionResult tryConnect(String host, int port) {
+    try (Socket socket = new Socket(host, port)) {
+      return ConnectionResult.allowed(true);
+    } catch (SecurityException e) {
+      return ConnectionResult.denied(e.getMessage());
+    } catch (IOException e) {
+      // Connection allowed but failed due to network (host unreachable, port closed, etc.)
+      return ConnectionResult.allowed(false);
+    }
+  }
+}


### PR DESCRIPTION
## Description

  Extends network.outbound with optional host glob patterns and port/port-range
  filtering. Adds port range support to network.listen.

  New capability signatures:
  - network.outbound(host?, port?) - host glob + port/range filtering
  - network.listen(port?) - now accepts port ranges like "8080-8090"

  Host glob patterns:
  - `*` matches exactly one DNS segment (*.example.com matches api.example.com)
  - `**` matches one or more segments (**.example.com matches a.b.c.example.com)

  Implementation:
  - New HOST_PORT operation category in BootstrapEnforcer
  - HostMatcher: segment-based DNS pattern matching with normalization
  - PortRange: port and port-range parsing/matching
  - PolicyValidator: semantic validation for host patterns and port specs
  - PolicyEnforcer: HOST_PORT category handler with per-entitlement matching

  Sandbox demo:
  - RestrictedNetworkClient demonstrates host/port filtering
  - Shows ALLOWED (api.example.com:443) vs DENIED (evil.com:443, :8080)
