### PR TITLE
Add environment variable and system property access control

### DIFF
--- a/DEVELOPMENT_PLAN.md
+++ b/DEVELOPMENT_PLAN.md
@@ -340,10 +340,49 @@ Exit criteria:
 
 ---
 
+### M4.7 — Environment Variable and System Property Access ✓
+
+Added enforcement for environment variable and system property access:
+
+* **`env.read(pattern?)`** — controls access to environment variables
+  * `env.read` (no args) - allows reading any env var and bulk access via `System.getenv()`
+  * `env.read("HOME")` - allows reading specific env var only
+  * `env.read("*")` - explicit wildcard for any env var
+  * Bulk access (`System.getenv()` with no args) requires no-arg or `*` entitlement
+
+* **`system.property.read(pattern?)`** — controls access to system properties
+  * `system.property.read` (no args) - allows reading any property and bulk access
+  * `system.property.read("java.home")` - allows reading specific property only
+  * Bulk access (`System.getProperties()`) requires no-arg or `*` entitlement
+
+* **`system.property.write(pattern?)`** — controls modification of system properties
+  * `system.property.write` (no args) - allows writing any property and bulk access
+  * `system.property.write("app.config")` - allows writing specific property only
+  * Bulk access (`System.setProperties()`) requires no-arg or `*` entitlement
+  * `System.clearProperty()` also requires write permission
+
+Implementation:
+
+* Reuses `TARGET_PATTERN` category with bulk access gating
+* Reentrancy guard prevents recursion when jGuard reads properties internally
+* Empty pattern validation prevents accidental policy bypass
+* Instrumented methods:
+  * `System.getenv()`, `System.getenv(String)`
+  * `System.getProperty(String)`, `System.getProperty(String, String)`, `System.getProperties()`
+  * `System.setProperty(String, String)`, `System.setProperties(Properties)`, `System.clearProperty(String)`
+
+Exit criteria:
+
+* demonstrable prevention of unauthorized env var access ✓
+* demonstrable prevention of unauthorized property access ✓
+* bulk APIs properly gated ✓
+
+---
+
 ### M5 — Integration proof ✓
 
 * `samples/sandbox-demo` demonstrates full integration
-* Policy-driven behavior change across all 6 capabilities
+* Policy-driven behavior change across all 9 capabilities
 * Entitled vs unentitled operations clearly demonstrated
 * `./gradlew runWithAgent` for enforcement testing
 
@@ -386,6 +425,9 @@ Remaining for v0.1.0 release:
 | `network.listen(port?)` | ✓ | PORT |
 | `threads.create` | ✓ | SIMPLE |
 | `native.load(pattern?)` | ✓ | TARGET_PATTERN |
+| `env.read(pattern?)` | ✓ | TARGET_PATTERN |
+| `system.property.read(pattern?)` | ✓ | TARGET_PATTERN |
+| `system.property.write(pattern?)` | ✓ | TARGET_PATTERN |
 
 Additional features:
 
@@ -398,6 +440,8 @@ Additional features:
 | Comprehensive documentation | ✓ |
 | Network host/port filtering | ✓ |
 | Port range support | ✓ |
+| Env/property access control | ✓ |
+| Bulk API gating (getenv(), getProperties()) | ✓ |
 
 ---
 
@@ -444,7 +488,6 @@ Instrumented APIs:
 
 Potential additions:
 
-* `env.read` / `env.write` — environment variable access
 * `classloader.create` — custom classloader creation
-* `system.property.read` / `system.property.write` — system property access
+* `serialization.read` / `serialization.write` — object serialization control
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ Examples include:
 * `network.listen(portSpec?)` — bind server sockets to ports (supports port ranges)
 * `threads.create` — create new threads
 * `native.load(pattern?)` — load native libraries
+* `env.read(pattern?)` — read environment variables
+* `system.property.read(pattern?)` — read system properties
+* `system.property.write(pattern?)` — write system properties
 
 **Host patterns** for `network.outbound`:
 * `*` — matches one DNS segment (e.g., `*.example.com`)
@@ -151,6 +154,8 @@ jGuard enforces policy at a small number of high-impact guard points:
 * outbound network connections
 * thread creation and management
 * native library loading
+* environment variable access
+* system property access
 
 At runtime:
 
@@ -276,6 +281,8 @@ Completed:
 * Network enforcement (`network.outbound`, `network.listen`)
 * Thread creation enforcement (`threads.create`)
 * Native library loading enforcement (`native.load`)
+* Environment variable access enforcement (`env.read`)
+* System property access enforcement (`system.property.read`, `system.property.write`)
 * Policy hot reload (update entitlements without restart)
 * Clear failure semantics with configurable modes (STRICT, PERMISSIVE, AUDIT)
 * Strong JPMS integration with module verification

--- a/agent-bootstrap/src/main/java/org/jguard/bootstrap/BootstrapEnforcer.java
+++ b/agent-bootstrap/src/main/java/org/jguard/bootstrap/BootstrapEnforcer.java
@@ -84,7 +84,7 @@ public final class BootstrapEnforcer {
   private static volatile String[] skipPrefixes = DEFAULT_SKIP_PREFIXES;
 
   /** Flag to prevent re-entrant calls during enforcement. */
-  private static final ThreadLocal<Boolean> IN_ENFORCEMENT = ThreadLocal.withInitial(() -> false);
+  private static final ThreadLocal<Boolean> IN_ENFORCEMENT = new ThreadLocal<>();
 
   private BootstrapEnforcer() {}
 
@@ -280,6 +280,37 @@ public final class BootstrapEnforcer {
     dispatch(Operation.NATIVE_LOAD, libraryName != null ? libraryName : "unknown", 0);
   }
 
+  // ========== ENVIRONMENT VARIABLE ENTRY POINTS ==========
+
+  /**
+   * Called by ByteBuddy advice when an environment variable is being read.
+   *
+   * @param name the env var name, or null if reading all (System.getenv())
+   */
+  public static void onEnvRead(String name) {
+    dispatch(Operation.ENV_READ, name, 0);
+  }
+
+  // ========== SYSTEM PROPERTY ENTRY POINTS ==========
+
+  /**
+   * Called by ByteBuddy advice when a system property is being read.
+   *
+   * @param key the property key, or null if reading all (System.getProperties())
+   */
+  public static void onPropertyRead(String key) {
+    dispatch(Operation.PROP_READ, key, 0);
+  }
+
+  /**
+   * Called by ByteBuddy advice when a system property is being written.
+   *
+   * @param key the property key, or null if replacing all (System.setProperties())
+   */
+  public static void onPropertyWrite(String key) {
+    dispatch(Operation.PROP_WRITE, key, 0);
+  }
+
   // ========== SINGLE DISPATCH ==========
 
   /**
@@ -307,10 +338,10 @@ public final class BootstrapEnforcer {
     }
 
     try {
-      IN_ENFORCEMENT.set(true);
+      IN_ENFORCEMENT.set(Boolean.TRUE);
       enforce(op, arg0, arg1, cb);
     } finally {
-      IN_ENFORCEMENT.set(false);
+      IN_ENFORCEMENT.remove();
     }
   }
 

--- a/agent-bootstrap/src/main/java/org/jguard/bootstrap/Operation.java
+++ b/agent-bootstrap/src/main/java/org/jguard/bootstrap/Operation.java
@@ -68,7 +68,28 @@ public enum Operation {
    *
    * <p>Arguments: {@code arg0} = library name, {@code arg1} = 0
    */
-  NATIVE_LOAD("native.load", Category.TARGET_PATTERN);
+  NATIVE_LOAD("native.load", Category.TARGET_PATTERN),
+
+  /**
+   * Environment variable read.
+   *
+   * <p>Arguments: {@code arg0} = env var name (null for bulk getenv()), {@code arg1} = 0
+   */
+  ENV_READ("env.read", Category.TARGET_PATTERN),
+
+  /**
+   * System property read.
+   *
+   * <p>Arguments: {@code arg0} = property key (null for bulk getProperties()), {@code arg1} = 0
+   */
+  PROP_READ("system.property.read", Category.TARGET_PATTERN),
+
+  /**
+   * System property write.
+   *
+   * <p>Arguments: {@code arg0} = property key (null for bulk setProperties()), {@code arg1} = 0
+   */
+  PROP_WRITE("system.property.write", Category.TARGET_PATTERN);
 
   /**
    * Categories determine matching logic in PolicyEnforcer.
@@ -117,8 +138,12 @@ public enum Operation {
     /**
      * Target pattern capabilities with optional pattern matching.
      *
-     * <p>Policy args: none (any target) or {@code (pattern)} for specific targets. Use for
-     * reflection, native loading, process execution, etc.
+     * <p>Policy args: none (any target) or {@code (pattern)} for specific targets. Use for native
+     * loading, environment variable access, system property access, etc.
+     *
+     * <p>When {@code arg0} is null, it indicates a bulk access (e.g., {@code System.getenv()},
+     * {@code System.getProperties()}). Bulk access requires no-arg entitlement or {@code "*"}
+     * pattern.
      */
     TARGET_PATTERN
   }

--- a/agent/README.md
+++ b/agent/README.md
@@ -209,6 +209,28 @@ Runtime native loading is instrumented:
 - `Runtime.loadLibrary(String)`
 - `Runtime.load(String)`
 
+## Instrumented Classes (Environment Variables)
+
+### java.lang.System
+
+Environment variable access is instrumented:
+
+- `System.getenv()` — bulk read (requires no-arg or `*` entitlement)
+- `System.getenv(String)` — single variable read
+
+## Instrumented Classes (System Properties)
+
+### java.lang.System
+
+System property access is instrumented:
+
+- `System.getProperty(String)` — single property read
+- `System.getProperty(String, String)` — single property read with default
+- `System.getProperties()` — bulk read (requires no-arg or `*` entitlement)
+- `System.setProperty(String, String)` — single property write
+- `System.setProperties(Properties)` — bulk write (requires no-arg or `*` entitlement)
+- `System.clearProperty(String)` — single property removal (write)
+
 ## Limitations
 
 ### Current Scope
@@ -221,12 +243,23 @@ The following capabilities are fully enforced:
 - `network.listen(portSpec?)` — server socket binding with optional port or port range
 - `threads.create` — thread creation
 - `native.load(pattern?)` — native library loading
+- `env.read(pattern?)` — environment variable read access
+- `system.property.read(pattern?)` — system property read access
+- `system.property.write(pattern?)` — system property write access
 
 **Host patterns** for `network.outbound`:
 - `*` matches exactly one DNS segment (e.g., `*.example.com` matches `api.example.com`)
 - `**` matches one or more DNS segments (e.g., `**.example.com` matches `a.b.c.example.com`)
 
 **Port specs** can be integers (`443`) or ranges (`"8080-8090"`).
+
+**Target patterns** for `env.read`, `system.property.read/write`, `native.load`:
+- No argument or `*` — matches any target (also grants bulk API access)
+- `HOME` — exact match for specific target
+- `app.**` — matches `app` and all descendants (e.g., `app.config.setting`)
+- `app.*` — matches direct children only (e.g., `app.config` but not `app.config.setting`)
+
+**Bulk API gating**: Methods like `System.getenv()`, `System.getProperties()`, and `System.setProperties()` require no-arg or `*` entitlement. Specific patterns do not grant bulk access.
 
 ### JVM Bootstrap Operations
 

--- a/agent/src/main/java/org/jguard/agent/AgentInitializer.java
+++ b/agent/src/main/java/org/jguard/agent/AgentInitializer.java
@@ -12,6 +12,7 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.none;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
 
 import java.io.IOException;
 import java.lang.instrument.Instrumentation;
@@ -367,17 +368,63 @@ public final class AgentInitializer {
                     Advice.to(ThreadInterceptor.ThreadStartAdvice.class)
                         .on(named("start").and(takesArguments(0)))))
         // ========== NATIVE LIBRARY INSTRUMENTATION (native.load) ==========
-        // Instrument java.lang.System - native library loading
+        // Instrument java.lang.System - native library loading, env, and property access
         .type(named("java.lang.System"))
         .transform(
             (builder, typeDescription, classLoader, module, protectionDomain) ->
                 builder
+                    // Native library loading
                     .visit(
                         Advice.to(NativeInterceptor.LoadLibraryAdvice.class)
                             .on(named("loadLibrary").and(takesArgument(0, String.class))))
                     .visit(
                         Advice.to(NativeInterceptor.LoadAdvice.class)
-                            .on(named("load").and(takesArgument(0, String.class)))))
+                            .on(named("load").and(takesArgument(0, String.class))))
+                    // ========== ENVIRONMENT VARIABLE ACCESS (env.read) ==========
+                    // System.getenv() - bulk read (returns Map<String, String>)
+                    .visit(
+                        Advice.to(EnvInterceptor.GetEnvAllAdvice.class)
+                            .on(named("getenv").and(takesNoArguments())))
+                    // System.getenv(String) - single variable read
+                    .visit(
+                        Advice.to(EnvInterceptor.GetEnvAdvice.class)
+                            .on(named("getenv").and(takesArgument(0, String.class))))
+                    // ========== SYSTEM PROPERTY ACCESS (system.property.read/write) ==========
+                    // System.getProperty(String) - single property read
+                    .visit(
+                        Advice.to(PropertyInterceptor.GetPropertyAdvice.class)
+                            .on(
+                                named("getProperty")
+                                    .and(takesArgument(0, String.class))
+                                    .and(takesArguments(1))))
+                    // System.getProperty(String, String) - single property read with default
+                    .visit(
+                        Advice.to(PropertyInterceptor.GetPropertyAdvice.class)
+                            .on(
+                                named("getProperty")
+                                    .and(takesArgument(0, String.class))
+                                    .and(takesArgument(1, String.class))))
+                    // System.getProperties() - bulk property read
+                    .visit(
+                        Advice.to(PropertyInterceptor.GetPropertiesAdvice.class)
+                            .on(named("getProperties").and(takesNoArguments())))
+                    // System.setProperty(String, String) - single property write
+                    .visit(
+                        Advice.to(PropertyInterceptor.SetPropertyAdvice.class)
+                            .on(
+                                named("setProperty")
+                                    .and(takesArgument(0, String.class))
+                                    .and(takesArgument(1, String.class))))
+                    // System.setProperties(Properties) - bulk property write
+                    .visit(
+                        Advice.to(PropertyInterceptor.SetPropertiesAdvice.class)
+                            .on(
+                                named("setProperties")
+                                    .and(takesArguments(java.util.Properties.class))))
+                    // System.clearProperty(String) - single property removal (write)
+                    .visit(
+                        Advice.to(PropertyInterceptor.ClearPropertyAdvice.class)
+                            .on(named("clearProperty").and(takesArgument(0, String.class)))))
         // Instrument java.lang.Runtime - native library loading (delegates to System)
         .type(named("java.lang.Runtime"))
         .transform(
@@ -403,7 +450,8 @@ public final class AgentInitializer {
       // Log discovery of classes we're interested in
       if (typeName.contains("Socket")
           || typeName.contains("ServerSocket")
-          || typeName.contains("Files")) {
+          || typeName.contains("Files")
+          || typeName.equals("java.lang.System")) {
         LOG.debug("Discovered: {} (loaded={})", typeName, loaded);
       }
     }
@@ -426,7 +474,9 @@ public final class AgentInitializer {
         boolean loaded) {
       // Log ignored classes we're interested in
       String name = typeDescription.getName();
-      if (name.contains("Socket") || name.equals("java.nio.file.Files")) {
+      if (name.contains("Socket")
+          || name.equals("java.nio.file.Files")
+          || name.equals("java.lang.System")) {
         LOG.debug("Ignored: {} (loaded={})", name, loaded);
       }
     }

--- a/agent/src/main/java/org/jguard/agent/EnvInterceptor.java
+++ b/agent/src/main/java/org/jguard/agent/EnvInterceptor.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The jGuard Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.jguard.agent;
+
+import net.bytebuddy.asm.Advice;
+import org.jguard.bootstrap.BootstrapEnforcer;
+
+/**
+ * ByteBuddy advice for intercepting environment variable access operations.
+ *
+ * <p>This class contains advice that is woven into JDK classes to enforce the {@code env.read}
+ * capability.
+ *
+ * <p>Instrumented methods:
+ *
+ * <ul>
+ *   <li>{@code System.getenv()} - reads all environment variables (bulk access)
+ *   <li>{@code System.getenv(String)} - reads a specific environment variable
+ * </ul>
+ *
+ * <h2>Bulk Access</h2>
+ *
+ * <p>The no-arg {@code System.getenv()} returns all environment variables. This requires either a
+ * no-arg {@code env.read} entitlement or an {@code env.read("*")} entitlement. Specific pattern
+ * entitlements like {@code env.read("HOME")} do not grant bulk access.
+ */
+public final class EnvInterceptor {
+
+  private EnvInterceptor() {}
+
+  /**
+   * Advice for System.getenv() - bulk read.
+   *
+   * <p>Intercepts bulk environment variable access. The caller must be entitled to read all
+   * environment variables (no-arg or "*" pattern).
+   */
+  public static class GetEnvAllAdvice {
+
+    private GetEnvAllAdvice() {}
+
+    @Advice.OnMethodEnter
+    public static void onEnter() {
+      // null indicates bulk access - requires no-arg or "*" entitlement
+      BootstrapEnforcer.onEnvRead(null);
+    }
+  }
+
+  /**
+   * Advice for System.getenv(String) - single variable read.
+   *
+   * <p>Intercepts access to a specific environment variable by name.
+   */
+  public static class GetEnvAdvice {
+
+    private GetEnvAdvice() {}
+
+    @Advice.OnMethodEnter
+    public static void onEnter(@Advice.Argument(0) String name) {
+      BootstrapEnforcer.onEnvRead(name);
+    }
+  }
+}

--- a/agent/src/main/java/org/jguard/agent/PolicyEnforcer.java
+++ b/agent/src/main/java/org/jguard/agent/PolicyEnforcer.java
@@ -355,9 +355,23 @@ public final class PolicyEnforcer {
   /**
    * Handles TARGET_PATTERN category - optional pattern restriction.
    *
-   * <p>Used for: reflect.invoke, native.load, process.exec, etc.
+   * <p>Used for: native.load, env.read, system.property.read/write, etc.
+   *
+   * <h2>Bulk Access</h2>
+   *
+   * <p>When {@code target} is null, it indicates bulk access (e.g., {@code System.getenv()}, {@code
+   * System.getProperties()}). Bulk access requires either:
+   *
+   * <ul>
+   *   <li>No-arg entitlement (e.g., {@code env.read}) - grants access to all targets
+   *   <li>Wildcard pattern (e.g., {@code env.read("*")}) - explicit wildcard
+   * </ul>
+   *
+   * <p>Specific pattern entitlements like {@code env.read("HOME")} do NOT grant bulk access.
    */
   private boolean isAllowedTargetPattern(String callerPackage, String target, String capability) {
+    boolean isBulkAccess = (target == null);
+
     for (Entitlement entitlement : policy.entitlements()) {
       if (!entitlement.capability().name().equals(capability)) {
         continue;
@@ -368,17 +382,32 @@ public final class PolicyEnforcer {
 
       List<CapabilityArgument> args = entitlement.capability().arguments();
       if (args.isEmpty()) {
-        // No arguments - allows any target
+        // No arguments - allows any target (including bulk access)
         LOG.debug(
             "{} allowed (any target): package={}, target={}, entitlement={}",
             capability,
             callerPackage,
-            target,
+            target != null ? target : "bulk",
             entitlement);
         return true;
       } else if (args.size() == 1) {
-        // Pattern restriction - match target against pattern
         String pattern = ((CapabilityArgument.StringArg) args.get(0)).value();
+
+        // For bulk access, only no-arg or "*" pattern grants access
+        if (isBulkAccess) {
+          if ("*".equals(pattern)) {
+            LOG.debug(
+                "{} allowed (bulk, wildcard): package={}, entitlement={}",
+                capability,
+                callerPackage,
+                entitlement);
+            return true;
+          }
+          // Continue checking other entitlements - a specific pattern doesn't grant bulk access
+          continue;
+        }
+
+        // Pattern restriction - match target against pattern
         if (targetMatchesPattern(target, pattern)) {
           LOG.debug(
               "{} allowed (pattern match): package={}, target={}, pattern={}, entitlement={}",
@@ -392,17 +421,23 @@ public final class PolicyEnforcer {
       }
     }
 
-    LOG.debug("{} denied: package={}, target={}", capability, callerPackage, target);
+    LOG.debug(
+        "{} denied: package={}, target={}",
+        capability,
+        callerPackage,
+        target != null ? target : "bulk");
     return false;
   }
 
   /**
-   * Matches a target (class name, library path, etc.) against a pattern.
+   * Matches a target (env var name, property key, library path, etc.) against a pattern.
    *
    * <p>Pattern syntax:
    *
    * <ul>
-   *   <li>{@code com.example.Foo} - exact match
+   *   <li>{@code *} - matches any target
+   *   <li>{@code HOME} - exact match for simple names (env vars, properties)
+   *   <li>{@code com.example.Foo} - exact match for dotted names
    *   <li>{@code com.example.*} - matches direct children (com.example.Foo, not
    *       com.example.sub.Bar)
    *   <li>{@code com.example.**} - matches all descendants
@@ -411,6 +446,10 @@ public final class PolicyEnforcer {
   private boolean targetMatchesPattern(String target, String pattern) {
     if (target == null) {
       return false;
+    }
+    // Wildcard matches any non-null target
+    if ("*".equals(pattern)) {
+      return true;
     }
     if (pattern.endsWith(".**")) {
       String prefix = pattern.substring(0, pattern.length() - 3);

--- a/agent/src/main/java/org/jguard/agent/PropertyInterceptor.java
+++ b/agent/src/main/java/org/jguard/agent/PropertyInterceptor.java
@@ -1,0 +1,123 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The jGuard Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.jguard.agent;
+
+import net.bytebuddy.asm.Advice;
+import org.jguard.bootstrap.BootstrapEnforcer;
+
+/**
+ * ByteBuddy advice for intercepting system property access operations.
+ *
+ * <p>This class contains advice that is woven into JDK classes to enforce the {@code
+ * system.property.read} and {@code system.property.write} capabilities.
+ *
+ * <p>Instrumented methods:
+ *
+ * <ul>
+ *   <li>{@code System.getProperty(String)} - reads a specific property
+ *   <li>{@code System.getProperty(String, String)} - reads a specific property with default
+ *   <li>{@code System.getProperties()} - reads all properties (bulk access)
+ *   <li>{@code System.setProperty(String, String)} - sets a specific property
+ *   <li>{@code System.setProperties(Properties)} - replaces all properties (bulk write)
+ *   <li>{@code System.clearProperty(String)} - removes a specific property
+ * </ul>
+ *
+ * <h2>Bulk Access</h2>
+ *
+ * <p>The {@code System.getProperties()} method returns all system properties. This requires either
+ * a no-arg {@code system.property.read} entitlement or a {@code system.property.read("*")}
+ * entitlement.
+ *
+ * <p>The {@code System.setProperties(Properties)} method replaces all system properties. This
+ * requires either a no-arg {@code system.property.write} entitlement or a {@code
+ * system.property.write("*")} entitlement. Note that {@code setProperties(null)} is also a bulk
+ * operation (resets to initial VM properties).
+ */
+public final class PropertyInterceptor {
+
+  private PropertyInterceptor() {}
+
+  /**
+   * Advice for System.getProperty(String) and System.getProperty(String, String).
+   *
+   * <p>Intercepts access to a specific system property by key.
+   */
+  public static class GetPropertyAdvice {
+
+    private GetPropertyAdvice() {}
+
+    @Advice.OnMethodEnter
+    public static void onEnter(@Advice.Argument(0) String key) {
+      BootstrapEnforcer.onPropertyRead(key);
+    }
+  }
+
+  /**
+   * Advice for System.getProperties() - bulk read.
+   *
+   * <p>Intercepts bulk system property access. The caller must be entitled to read all system
+   * properties (no-arg or "*" pattern).
+   */
+  public static class GetPropertiesAdvice {
+
+    private GetPropertiesAdvice() {}
+
+    @Advice.OnMethodEnter
+    public static void onEnter() {
+      // null indicates bulk access - requires no-arg or "*" entitlement
+      BootstrapEnforcer.onPropertyRead(null);
+    }
+  }
+
+  /**
+   * Advice for System.setProperty(String, String).
+   *
+   * <p>Intercepts setting a specific system property by key.
+   */
+  public static class SetPropertyAdvice {
+
+    private SetPropertyAdvice() {}
+
+    @Advice.OnMethodEnter
+    public static void onEnter(@Advice.Argument(0) String key) {
+      BootstrapEnforcer.onPropertyWrite(key);
+    }
+  }
+
+  /**
+   * Advice for System.setProperties(Properties) - bulk write.
+   *
+   * <p>Intercepts bulk system property replacement. The caller must be entitled to write all system
+   * properties (no-arg or "*" pattern). Note that setProperties(null) is also a bulk operation.
+   */
+  public static class SetPropertiesAdvice {
+
+    private SetPropertiesAdvice() {}
+
+    @Advice.OnMethodEnter
+    public static void onEnter() {
+      // null indicates bulk access - requires no-arg or "*" entitlement
+      BootstrapEnforcer.onPropertyWrite(null);
+    }
+  }
+
+  /**
+   * Advice for System.clearProperty(String).
+   *
+   * <p>Intercepts removal of a specific system property by key. Clearing is a write operation.
+   */
+  public static class ClearPropertyAdvice {
+
+    private ClearPropertyAdvice() {}
+
+    @Advice.OnMethodEnter
+    public static void onEnter(@Advice.Argument(0) String key) {
+      BootstrapEnforcer.onPropertyWrite(key);
+    }
+  }
+}

--- a/agent/src/test/java/org/jguard/agent/PolicyEnforcerTest.java
+++ b/agent/src/test/java/org/jguard/agent/PolicyEnforcerTest.java
@@ -1007,6 +1007,234 @@ class PolicyEnforcerTest {
   }
 
   @Nested
+  @DisplayName("TARGET_PATTERN bulk access (env.read, system.property.read/write)")
+  class TargetPatternBulkAccessTest {
+
+    /** Helper for env.read operations. */
+    private void checkEnvRead(PolicyEnforcer enforcer, CallerContext caller, String name) {
+      SecurityException denial = enforcer.check(caller, Operation.ENV_READ, name, 0);
+      if (denial != null) {
+        throw denial;
+      }
+    }
+
+    /** Helper for system.property.read operations. */
+    private void checkPropertyRead(PolicyEnforcer enforcer, CallerContext caller, String key) {
+      SecurityException denial = enforcer.check(caller, Operation.PROP_READ, key, 0);
+      if (denial != null) {
+        throw denial;
+      }
+    }
+
+    /** Helper for system.property.write operations. */
+    private void checkPropertyWrite(PolicyEnforcer enforcer, CallerContext caller, String key) {
+      SecurityException denial = enforcer.check(caller, Operation.PROP_WRITE, key, 0);
+      if (denial != null) {
+        throw denial;
+      }
+    }
+
+    @Test
+    @DisplayName("env.read allows bulk access with no-arg entitlement")
+    void envReadAllowsBulkAccessNoArg() {
+      Entitlement entitlement =
+          new Entitlement(SubjectPattern.module(), CapabilityGrant.of("env.read"));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      // null = bulk access (System.getenv())
+      assertThatCode(() -> checkEnvRead(enforcer, caller("com.example.app"), null))
+          .doesNotThrowAnyException();
+      // Single access also allowed
+      assertThatCode(() -> checkEnvRead(enforcer, caller("com.example.app"), "HOME"))
+          .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("env.read allows bulk access with * pattern")
+    void envReadAllowsBulkAccessWildcard() {
+      Entitlement entitlement =
+          new Entitlement(
+              SubjectPattern.module(),
+              CapabilityGrant.of("env.read", List.of(new CapabilityArgument.StringArg("*"))));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      // null = bulk access
+      assertThatCode(() -> checkEnvRead(enforcer, caller("com.example.app"), null))
+          .doesNotThrowAnyException();
+      // Single access also allowed
+      assertThatCode(() -> checkEnvRead(enforcer, caller("com.example.app"), "PATH"))
+          .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("env.read denies bulk access with specific pattern")
+    void envReadDeniesBulkAccessSpecificPattern() {
+      Entitlement entitlement =
+          new Entitlement(
+              SubjectPattern.module(),
+              CapabilityGrant.of("env.read", List.of(new CapabilityArgument.StringArg("HOME"))));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      // null = bulk access - DENIED
+      assertThatThrownBy(() -> checkEnvRead(enforcer, caller("com.example.app"), null))
+          .isInstanceOf(SecurityException.class)
+          .hasMessageContaining("env.read");
+
+      // Single access to matching name allowed
+      assertThatCode(() -> checkEnvRead(enforcer, caller("com.example.app"), "HOME"))
+          .doesNotThrowAnyException();
+
+      // Single access to non-matching name denied
+      assertThatThrownBy(() -> checkEnvRead(enforcer, caller("com.example.app"), "PATH"))
+          .isInstanceOf(SecurityException.class);
+    }
+
+    @Test
+    @DisplayName("system.property.read allows bulk access with no-arg entitlement")
+    void propReadAllowsBulkAccessNoArg() {
+      Entitlement entitlement =
+          new Entitlement(SubjectPattern.module(), CapabilityGrant.of("system.property.read"));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      // null = bulk access (System.getProperties())
+      assertThatCode(() -> checkPropertyRead(enforcer, caller("com.example.app"), null))
+          .doesNotThrowAnyException();
+      // Single access also allowed
+      assertThatCode(() -> checkPropertyRead(enforcer, caller("com.example.app"), "java.home"))
+          .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("system.property.read allows bulk access with * pattern")
+    void propReadAllowsBulkAccessWildcard() {
+      Entitlement entitlement =
+          new Entitlement(
+              SubjectPattern.module(),
+              CapabilityGrant.of(
+                  "system.property.read", List.of(new CapabilityArgument.StringArg("*"))));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      // null = bulk access
+      assertThatCode(() -> checkPropertyRead(enforcer, caller("com.example.app"), null))
+          .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("system.property.read denies bulk access with specific pattern")
+    void propReadDeniesBulkAccessSpecificPattern() {
+      Entitlement entitlement =
+          new Entitlement(
+              SubjectPattern.module(),
+              CapabilityGrant.of(
+                  "system.property.read", List.of(new CapabilityArgument.StringArg("java.home"))));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      // null = bulk access - DENIED
+      assertThatThrownBy(() -> checkPropertyRead(enforcer, caller("com.example.app"), null))
+          .isInstanceOf(SecurityException.class)
+          .hasMessageContaining("system.property.read");
+
+      // Single access to matching key allowed
+      assertThatCode(() -> checkPropertyRead(enforcer, caller("com.example.app"), "java.home"))
+          .doesNotThrowAnyException();
+
+      // Single access to non-matching key denied
+      assertThatThrownBy(() -> checkPropertyRead(enforcer, caller("com.example.app"), "user.home"))
+          .isInstanceOf(SecurityException.class);
+    }
+
+    @Test
+    @DisplayName("system.property.write allows bulk access with no-arg entitlement")
+    void propWriteAllowsBulkAccessNoArg() {
+      Entitlement entitlement =
+          new Entitlement(SubjectPattern.module(), CapabilityGrant.of("system.property.write"));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      // null = bulk access (System.setProperties())
+      assertThatCode(() -> checkPropertyWrite(enforcer, caller("com.example.app"), null))
+          .doesNotThrowAnyException();
+      // Single access also allowed
+      assertThatCode(() -> checkPropertyWrite(enforcer, caller("com.example.app"), "app.config"))
+          .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("system.property.write denies bulk access with specific pattern")
+    void propWriteDeniesBulkAccessSpecificPattern() {
+      Entitlement entitlement =
+          new Entitlement(
+              SubjectPattern.module(),
+              CapabilityGrant.of(
+                  "system.property.write",
+                  List.of(new CapabilityArgument.StringArg("app.config"))));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      // null = bulk access - DENIED
+      assertThatThrownBy(() -> checkPropertyWrite(enforcer, caller("com.example.app"), null))
+          .isInstanceOf(SecurityException.class)
+          .hasMessageContaining("system.property.write");
+
+      // Single access to matching key allowed
+      assertThatCode(() -> checkPropertyWrite(enforcer, caller("com.example.app"), "app.config"))
+          .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("respects package scope for env.read")
+    void respectsPackageScopeForEnvRead() {
+      Entitlement entitlement =
+          new Entitlement(
+              SubjectPattern.exactPackage("com.example.app.config"),
+              CapabilityGrant.of("env.read"));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      // Entitled package allowed
+      assertThatCode(() -> checkEnvRead(enforcer, caller("com.example.app.config"), "HOME"))
+          .doesNotThrowAnyException();
+
+      // Other packages denied
+      assertThatThrownBy(() -> checkEnvRead(enforcer, caller("com.example.app"), "HOME"))
+          .isInstanceOf(SecurityException.class);
+    }
+
+    @Test
+    @DisplayName("native.load * pattern matches any target")
+    void nativeLoadWildcardMatchesAny() {
+      Entitlement entitlement =
+          new Entitlement(
+              SubjectPattern.module(),
+              CapabilityGrant.of("native.load", List.of(new CapabilityArgument.StringArg("*"))));
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of(entitlement));
+
+      PolicyEnforcer enforcer = createEnforcer(policy);
+
+      // Any library name should be allowed
+      assertThatCode(() -> checkNativeLoad(enforcer, caller("com.example.app"), "libcrypto"))
+          .doesNotThrowAnyException();
+      assertThatCode(() -> checkNativeLoad(enforcer, caller("com.example.app"), "anything.at.all"))
+          .doesNotThrowAnyException();
+    }
+  }
+
+  @Nested
   @DisplayName("PORT category with ranges (network.listen)")
   class PortRangeOperationTest {
 

--- a/agent/src/test/java/org/jguard/agent/PolicyReloaderTest.java
+++ b/agent/src/test/java/org/jguard/agent/PolicyReloaderTest.java
@@ -174,8 +174,8 @@ class PolicyReloaderTest {
   @Test
   @DisplayName("uses configured poll interval")
   void usesConfiguredPollInterval() throws Exception {
-    // Use 3 second poll interval
-    reloader = new PolicyReloader(policyPath, enforcerRef, config, 3);
+    // Use 2 second poll interval
+    reloader = new PolicyReloader(policyPath, enforcerRef, config, 2);
     reloader.start();
 
     PolicyEnforcer initialEnforcer = enforcerRef.get();
@@ -184,14 +184,14 @@ class PolicyReloaderTest {
     PolicyDescriptor newPolicy = createPolicy("com.example.app", "threads.create");
     writePolicyFile(policyPath, newPolicy);
 
-    // Wait 1.5 seconds - less than poll interval
-    Thread.sleep(1500);
+    // Wait 500ms - well below poll interval
+    Thread.sleep(500);
 
     // Should not have reloaded yet
     assertThat(enforcerRef.get()).isSameAs(initialEnforcer);
 
-    // Wait for remaining poll time + buffer
-    Thread.sleep(2500);
+    // Wait for poll time + generous buffer for slow CI machines
+    Thread.sleep(4000);
 
     // Now should have reloaded
     assertThat(enforcerRef.get()).isNotSameAs(initialEnforcer);

--- a/docs/spec/jguard-policy-descriptor.md
+++ b/docs/spec/jguard-policy-descriptor.md
@@ -222,14 +222,17 @@ Each capability has a fixed signature that determines:
 
 The following capabilities are defined in jGuard version 1:
 
-| Capability         | Signature                    | Description                              |
-| ------------------ | ---------------------------- | ---------------------------------------- |
-| `fs.read`          | `(root, glob)`               | Read files matching glob under root      |
-| `fs.write`         | `(root, glob)`               | Write files matching glob under root     |
-| `network.outbound` | `(hostPattern?, portSpec?)`  | Open outbound network connections        |
-| `network.listen`   | `(portSpec?)`                | Bind server sockets (optional port/range)|
-| `threads.create`   | (no arguments)               | Create new threads                       |
-| `native.load`      | `(pattern?)`                 | Load native libraries (optional pattern) |
+| Capability              | Signature                    | Description                              |
+| ----------------------- | ---------------------------- | ---------------------------------------- |
+| `fs.read`               | `(root, glob)`               | Read files matching glob under root      |
+| `fs.write`              | `(root, glob)`               | Write files matching glob under root     |
+| `network.outbound`      | `(hostPattern?, portSpec?)`  | Open outbound network connections        |
+| `network.listen`        | `(portSpec?)`                | Bind server sockets (optional port/range)|
+| `threads.create`        | (no arguments)               | Create new threads                       |
+| `native.load`           | `(pattern?)`                 | Load native libraries (optional pattern) |
+| `env.read`              | `(pattern?)`                 | Read environment variables               |
+| `system.property.read`  | `(pattern?)`                 | Read system properties                   |
+| `system.property.write` | `(pattern?)`                 | Write system properties                  |
 
 #### Argument details
 
@@ -274,6 +277,44 @@ entitle module to network.listen("8080-8090"); // Port range
 **`native.load(pattern?)`**
 
 * `pattern` — optional library name pattern (string); if omitted, allows loading any library
+
+**`env.read(pattern?)`**
+
+* `pattern` — optional environment variable name pattern (string); if omitted, allows reading any env var
+
+Pattern syntax:
+* No argument or `*` — matches any env var (also grants bulk access via `System.getenv()`)
+* `HOME` — exact match for specific variable
+* Bulk API `System.getenv()` requires no-arg or `*` entitlement
+
+Examples:
+```
+entitle module to env.read;              // Any env var, including bulk access
+entitle module to env.read("HOME");      // Only HOME variable
+entitle module to env.read("*");         // Any env var, including bulk access
+```
+
+**`system.property.read(pattern?)` / `system.property.write(pattern?)`**
+
+* `pattern` — optional property key pattern (string); if omitted, allows any property
+
+Pattern syntax:
+* No argument or `*` — matches any property (also grants bulk access)
+* `java.home` — exact match for specific property
+* `app.**` — matches `app` and all descendants (e.g., `app.config.setting`)
+* `app.*` — matches direct children only (e.g., `app.config` but not `app.config.setting`)
+
+Bulk APIs:
+* `System.getProperties()` requires `system.property.read` with no-arg or `*`
+* `System.setProperties(Properties)` requires `system.property.write` with no-arg or `*`
+* `System.clearProperty(String)` requires `system.property.write` for that key
+
+Examples:
+```
+entitle module to system.property.read;                    // Any property, including bulk
+entitle module to system.property.read("java.home");       // Only java.home
+entitle module to system.property.write("app.**");         // Write app.* hierarchy
+```
 
 Implementations MUST reject entitlement declarations whose arguments do not conform to the capability's signature.
 

--- a/policy/src/main/java/org/jguard/policy/validation/PolicyValidator.java
+++ b/policy/src/main/java/org/jguard/policy/validation/PolicyValidator.java
@@ -39,16 +39,25 @@ public final class PolicyValidator {
   private static final Pattern JAVA_IDENTIFIER = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_]*$");
 
   // Known capabilities and their expected argument counts
-  // For v0.1.0: fs.read/write, network.outbound/listen, threads.create, native.load
+  // Capabilities: fs.read/write, network.outbound/listen, threads.create, native.load,
+  // env.read, system.property.read/write
   private static final Map<String, CapabilitySignature> KNOWN_CAPABILITIES =
-      Map.of(
-          "fs.read", new CapabilitySignature(2, 2, List.of(ArgType.STRING, ArgType.STRING)),
-          "fs.write", new CapabilitySignature(2, 2, List.of(ArgType.STRING, ArgType.STRING)),
-          "network.outbound",
-              new CapabilitySignature(0, 2, List.of(ArgType.STRING, ArgType.STRING_OR_INTEGER)),
-          "network.listen", new CapabilitySignature(0, 1, List.of(ArgType.STRING_OR_INTEGER)),
-          "threads.create", new CapabilitySignature(0, 0, List.of()),
-          "native.load", new CapabilitySignature(0, 1, List.of(ArgType.STRING)));
+      Map.ofEntries(
+          Map.entry(
+              "fs.read", new CapabilitySignature(2, 2, List.of(ArgType.STRING, ArgType.STRING))),
+          Map.entry(
+              "fs.write", new CapabilitySignature(2, 2, List.of(ArgType.STRING, ArgType.STRING))),
+          Map.entry(
+              "network.outbound",
+              new CapabilitySignature(0, 2, List.of(ArgType.STRING, ArgType.STRING_OR_INTEGER))),
+          Map.entry(
+              "network.listen", new CapabilitySignature(0, 1, List.of(ArgType.STRING_OR_INTEGER))),
+          Map.entry("threads.create", new CapabilitySignature(0, 0, List.of())),
+          Map.entry("native.load", new CapabilitySignature(0, 1, List.of(ArgType.STRING))),
+          Map.entry("env.read", new CapabilitySignature(0, 1, List.of(ArgType.STRING))),
+          Map.entry("system.property.read", new CapabilitySignature(0, 1, List.of(ArgType.STRING))),
+          Map.entry(
+              "system.property.write", new CapabilitySignature(0, 1, List.of(ArgType.STRING))));
 
   private final String sourcePath;
   private final List<CompilationResult.Diagnostic> diagnostics = new ArrayList<>();
@@ -193,6 +202,10 @@ public final class PolicyValidator {
     switch (name) {
       case "network.outbound" -> validateNetworkOutbound(args, location);
       case "network.listen" -> validateNetworkListen(args, location);
+      case "env.read" -> validateTargetPattern(name, args, location);
+      case "system.property.read" -> validateTargetPattern(name, args, location);
+      case "system.property.write" -> validateTargetPattern(name, args, location);
+      case "native.load" -> validateTargetPattern(name, args, location);
       default -> {
         // Other capabilities don't need semantic validation yet
       }
@@ -224,6 +237,36 @@ public final class PolicyValidator {
       return; // OK: any port
     }
     validatePortSpec(args.get(0), location);
+  }
+
+  /**
+   * Validates a target pattern for capabilities like env.read, system.property.read/write,
+   * native.load.
+   *
+   * <p>Empty patterns are rejected to prevent accidental policy bypass. Use no-arg or "*" for "any
+   * target".
+   */
+  private void validateTargetPattern(
+      String capabilityName, List<Argument> args, SourceLocation location) {
+    if (args.isEmpty()) {
+      return; // OK: any target (no-arg)
+    }
+
+    Argument arg = args.get(0);
+    String pattern = null;
+    if (arg instanceof Argument.StringLiteral s) {
+      pattern = s.value();
+    } else if (arg instanceof Argument.Identifier id) {
+      pattern = id.value();
+    }
+
+    if (pattern != null && pattern.isEmpty()) {
+      error(
+          "Empty pattern for '"
+              + capabilityName
+              + "' is not allowed. Use no arguments or \"*\" for any target",
+          location);
+    }
   }
 
   private void validateHostPattern(String pattern, SourceLocation location) {

--- a/policy/src/test/java/org/jguard/policy/validation/PolicyValidatorTest.java
+++ b/policy/src/test/java/org/jguard/policy/validation/PolicyValidatorTest.java
@@ -485,6 +485,155 @@ class PolicyValidatorTest {
   }
 
   @Nested
+  class EnvAndPropertyValidationTest {
+
+    @Test
+    void acceptsEnvReadWithNoArgs() {
+      EntitlementDeclaration entitlement = moduleEntitlement("env.read");
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+      assertThat(result.isValid()).isTrue();
+    }
+
+    @Test
+    void acceptsEnvReadWithPattern() {
+      EntitlementDeclaration entitlement = moduleEntitlement("env.read", stringArg("HOME"));
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+      assertThat(result.isValid()).isTrue();
+    }
+
+    @Test
+    void acceptsEnvReadWithWildcard() {
+      EntitlementDeclaration entitlement = moduleEntitlement("env.read", stringArg("*"));
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+      assertThat(result.isValid()).isTrue();
+    }
+
+    @Test
+    void rejectsEnvReadWithEmptyPattern() {
+      EntitlementDeclaration entitlement = moduleEntitlement("env.read", stringArg(""));
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+
+      assertThat(result.hasErrors()).isTrue();
+      assertThat(result.diagnostics())
+          .anyMatch(d -> d.message().contains("Empty pattern") && d.message().contains("env.read"));
+    }
+
+    @Test
+    void acceptsSystemPropertyReadWithNoArgs() {
+      EntitlementDeclaration entitlement = moduleEntitlement("system.property.read");
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+      assertThat(result.isValid()).isTrue();
+    }
+
+    @Test
+    void acceptsSystemPropertyReadWithPattern() {
+      EntitlementDeclaration entitlement =
+          moduleEntitlement("system.property.read", stringArg("java.home"));
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+      assertThat(result.isValid()).isTrue();
+    }
+
+    @Test
+    void rejectsSystemPropertyReadWithEmptyPattern() {
+      EntitlementDeclaration entitlement = moduleEntitlement("system.property.read", stringArg(""));
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+
+      assertThat(result.hasErrors()).isTrue();
+      assertThat(result.diagnostics())
+          .anyMatch(
+              d ->
+                  d.message().contains("Empty pattern")
+                      && d.message().contains("system.property.read"));
+    }
+
+    @Test
+    void acceptsSystemPropertyWriteWithNoArgs() {
+      EntitlementDeclaration entitlement = moduleEntitlement("system.property.write");
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+      assertThat(result.isValid()).isTrue();
+    }
+
+    @Test
+    void acceptsSystemPropertyWriteWithPattern() {
+      EntitlementDeclaration entitlement =
+          moduleEntitlement("system.property.write", stringArg("app.config"));
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+      assertThat(result.isValid()).isTrue();
+    }
+
+    @Test
+    void rejectsSystemPropertyWriteWithEmptyPattern() {
+      EntitlementDeclaration entitlement =
+          moduleEntitlement("system.property.write", stringArg(""));
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+
+      assertThat(result.hasErrors()).isTrue();
+      assertThat(result.diagnostics())
+          .anyMatch(
+              d ->
+                  d.message().contains("Empty pattern")
+                      && d.message().contains("system.property.write"));
+    }
+
+    @Test
+    void rejectsNativeLoadWithEmptyPattern() {
+      EntitlementDeclaration entitlement = moduleEntitlement("native.load", stringArg(""));
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+
+      assertThat(result.hasErrors()).isTrue();
+      assertThat(result.diagnostics())
+          .anyMatch(
+              d -> d.message().contains("Empty pattern") && d.message().contains("native.load"));
+    }
+
+    @Test
+    void rejectsEnvReadWithIntegerArg() {
+      // env.read must take a string argument, not integer
+      EntitlementDeclaration entitlement = moduleEntitlement("env.read", intArg(123));
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+
+      assertThat(result.hasErrors()).isTrue();
+      assertThat(result.diagnostics()).anyMatch(d -> d.message().contains("must be string"));
+    }
+
+    @Test
+    void rejectsEnvReadWithTooManyArgs() {
+      EntitlementDeclaration entitlement =
+          moduleEntitlement("env.read", stringArg("HOME"), stringArg("extra"));
+      PolicyFile ast = policyFile(List.of("app"), List.of(entitlement));
+
+      PolicyValidator.ValidationResult result = validate(ast);
+
+      assertThat(result.hasErrors()).isTrue();
+      assertThat(result.diagnostics()).anyMatch(d -> d.message().contains("requires 0 to 1"));
+    }
+  }
+
+  @Nested
   class NetworkListenSemanticValidationTest {
 
     @Test

--- a/samples/sandbox-demo/README.md
+++ b/samples/sandbox-demo/README.md
@@ -91,8 +91,16 @@ jGuard enforces your policy transparently—if the code is entitled, it runs; if
 | `network.listen(port?)` | Listen on a port (optional port or range like `"8080-8090"`) |
 | `threads.create` | Create threads |
 | `native.load(pattern?)` | Load native libraries (optional pattern) |
+| `env.read(pattern?)` | Read environment variables (optional pattern) |
+| `system.property.read(pattern?)` | Read system properties (optional pattern) |
+| `system.property.write(pattern?)` | Write system properties (optional pattern) |
 
 Host patterns: `*` matches one DNS segment, `**` matches one or more. Example: `*.example.com`
+
+Target patterns for `env.read`, `system.property.*`, `native.load`:
+- No arg or `*` — any target (also grants bulk API access)
+- `HOME` — exact match
+- `app.**` — matches `app` and all descendants
 
 ### Host/Port Filtering Example
 
@@ -213,7 +221,8 @@ sandbox-demo/
     │       │   └── restricted/
     │       │       └── RestrictedNetworkClient.java # Entitled to *.example.com:80-443 only
     │       ├── worker/BackgroundWorker.java       # Entitled to threads.create
-    │       └── nativelib/NativeLoader.java        # Entitled to native.load
+    │       ├── nativelib/NativeLoader.java        # Entitled to native.load
+    │       └── config/ConfigReader.java           # Entitled to env.read, system.property.write("app.**")
     └── test/java/
         └── org/jguard/samples/sandbox/
             └── EntitlementTest.java

--- a/samples/sandbox-demo/src/main/java/module-info.java
+++ b/samples/sandbox-demo/src/main/java/module-info.java
@@ -6,4 +6,5 @@ module org.jguard.samples.sandbox {
     exports org.jguard.samples.sandbox.net;
     exports org.jguard.samples.sandbox.net.restricted;
     exports org.jguard.samples.sandbox.worker;
+    exports org.jguard.samples.sandbox.config;
 }

--- a/samples/sandbox-demo/src/main/java/module-info.jguard
+++ b/samples/sandbox-demo/src/main/java/module-info.jguard
@@ -32,4 +32,20 @@ security module org.jguard.samples.sandbox {
     // Grant native library loading to the nativelib package
     entitle org.jguard.samples.sandbox.nativelib.. to native.load;
 
+    // Grant system property read access for the module
+    // This is needed because:
+    // 1. JDK classes read properties during class initialization (e.g., java.net.InetAddress)
+    // 2. These reads are attributed to the application code that triggered the initialization
+    // 3. The demo uses paths from user.home and java.io.tmpdir
+    // In production, you may want to use more specific patterns.
+    entitle module to system.property.read;
+
+    // Grant environment variable read access to specific package
+    // The .config package can read any env var
+    entitle org.jguard.samples.sandbox.config to env.read;
+
+    // Grant system property write access to specific package
+    // The .config package can write properties matching "app.**" (any depth)
+    entitle org.jguard.samples.sandbox.config to system.property.write("app.**");
+
 }

--- a/samples/sandbox-demo/src/main/java/org/jguard/samples/sandbox/Main.java
+++ b/samples/sandbox-demo/src/main/java/org/jguard/samples/sandbox/Main.java
@@ -18,6 +18,7 @@ import java.nio.file.Path;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.jguard.core.JGuard;
+import org.jguard.samples.sandbox.config.ConfigReader;
 import org.jguard.samples.sandbox.nativelib.NativeLoader;
 import org.jguard.samples.sandbox.net.NetworkClient;
 import org.jguard.samples.sandbox.net.NetworkServer;
@@ -38,6 +39,10 @@ import org.jguard.samples.sandbox.worker.BackgroundWorker;
  *   <li>network.listen - server socket binding (from org.jguard.samples.sandbox.net package)
  *   <li>threads.create - thread creation (from org.jguard.samples.sandbox.worker package)
  *   <li>native.load - native library loading (from org.jguard.samples.sandbox.nativelib package)
+ *   <li>env.read - environment variable access (from org.jguard.samples.sandbox.config package)
+ *   <li>system.property.read - system property read access (module-wide)
+ *   <li>system.property.write("app.**") - system property write with pattern (from
+ *       org.jguard.samples.sandbox.config package)
  * </ul>
  *
  * <h2>Running without the agent (no enforcement):</h2>
@@ -140,6 +145,22 @@ public final class Main {
 
     // Test 19: Native library load from non-entitled package (NOT ENTITLED)
     demonstrateUnentitledNativeAccess();
+
+    // === ENV/PROPERTY TESTS ===
+    System.out.println("--- ENV/PROPERTY TESTS ---");
+    System.out.println();
+
+    // Test 20: Env var read from entitled package (ENTITLED)
+    demonstrateEntitledEnvAccess();
+
+    // Test 21: Env var read from non-entitled package (NOT ENTITLED)
+    demonstrateUnentitledEnvAccess();
+
+    // Test 22: Property write from entitled package with matching pattern (ENTITLED)
+    demonstrateEntitledPropertyWrite();
+
+    // Test 23: Property write from entitled package with non-matching pattern (NOT ENTITLED)
+    demonstrateUnentitledPropertyWrite();
   }
 
   /**
@@ -630,6 +651,99 @@ public final class Main {
       // Library doesn't exist but operation was allowed - unexpected!
       System.out.println("  SUCCESS: Load attempt allowed (library not found)");
       System.out.println("  (This should be BLOCKED when running with the agent!)");
+    }
+
+    System.out.println();
+  }
+
+  /**
+   * Demonstrates environment variable reading from entitled package.
+   *
+   * <p>This operation IS entitled because it's called from the .config package which has env.read
+   * entitlement.
+   */
+  private static void demonstrateEntitledEnvAccess() {
+    System.out.println("[ENTITLED] env.read (from .config package)");
+    System.out.println("  Attempting to read HOME environment variable...");
+
+    ConfigReader.ConfigResult result = ConfigReader.readEnv("HOME");
+
+    if (result.allowed()) {
+      String value = result.value();
+      String display = value != null ? value : "(not set)";
+      System.out.println("  SUCCESS: HOME = " + display);
+    } else {
+      System.out.println("  BLOCKED (unexpected): " + result.message());
+    }
+
+    System.out.println();
+  }
+
+  /**
+   * Demonstrates environment variable reading from non-entitled package.
+   *
+   * <p>This operation is NOT entitled because Main is in the sandbox package, not the .config
+   * package. It should be blocked when the agent is active.
+   */
+  private static void demonstrateUnentitledEnvAccess() {
+    System.out.println("[NOT ENTITLED] env.read (from main package)");
+    System.out.println("  Attempting to read PATH environment variable directly...");
+
+    try {
+      // This call is made FROM this class (Main) which is in the .sandbox package
+      // which does NOT have env.read entitlement
+      String path = System.getenv("PATH");
+      System.out.println("  SUCCESS: PATH = " + (path != null ? path.substring(0, Math.min(50, path.length())) + "..." : "(not set)"));
+      System.out.println("  (This should be BLOCKED when running with the agent!)");
+    } catch (SecurityException e) {
+      System.out.println("  BLOCKED (expected): " + e.getMessage());
+    }
+
+    System.out.println();
+  }
+
+  /**
+   * Demonstrates system property writing from entitled package with matching pattern.
+   *
+   * <p>This operation IS entitled because it's called from the .config package which has
+   * system.property.write("app.**") entitlement, and "app.demo.setting" matches "app.**".
+   */
+  private static void demonstrateEntitledPropertyWrite() {
+    System.out.println("[ENTITLED] system.property.write(\"app.**\") (from .config package)");
+    System.out.println("  Attempting to set app.demo.setting property...");
+
+    ConfigReader.ConfigResult result = ConfigReader.writeProperty("app.demo.setting", "test-value");
+
+    if (result.allowed()) {
+      System.out.println("  SUCCESS: " + result.message());
+      // Verify the value was set
+      String value = System.getProperty("app.demo.setting");
+      System.out.println("  Verified: System.getProperty(\"app.demo.setting\") = " + value);
+    } else {
+      System.out.println("  BLOCKED (unexpected): " + result.message());
+    }
+
+    System.out.println();
+  }
+
+  /**
+   * Demonstrates system property writing from entitled package with NON-matching pattern.
+   *
+   * <p>This operation is NOT entitled because even though the .config package has
+   * system.property.write("app.**") entitlement, "java.home" does NOT match "app.**".
+   */
+  private static void demonstrateUnentitledPropertyWrite() {
+    System.out.println("[NOT ENTITLED] system.property.write to non-matching pattern");
+    System.out.println("  Attempting to set java.home property from .config package...");
+    System.out.println("  (Policy only allows writing properties matching \"app.**\")");
+
+    ConfigReader.ConfigResult result = ConfigReader.writeProperty("java.home", "/malicious/path");
+
+    if (result.allowed()) {
+      System.out.println("  SUCCESS: Write allowed (unexpected!)");
+      System.out.println("  (This should be BLOCKED when running with the agent!)");
+    } else {
+      System.out.println("  BLOCKED (expected): Property 'java.home' doesn't match 'app.**'");
     }
 
     System.out.println();

--- a/samples/sandbox-demo/src/main/java/org/jguard/samples/sandbox/config/ConfigReader.java
+++ b/samples/sandbox-demo/src/main/java/org/jguard/samples/sandbox/config/ConfigReader.java
@@ -1,0 +1,94 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The jGuard Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.jguard.samples.sandbox.config;
+
+/**
+ * Configuration reader with env.read and system.property.write capabilities.
+ *
+ * <p>This class is in the {@code org.jguard.samples.sandbox.config} package, which is granted:
+ *
+ * <ul>
+ *   <li>{@code env.read} - can read any environment variable
+ *   <li>{@code system.property.write("app.*")} - can write properties matching "app.*"
+ * </ul>
+ */
+public final class ConfigReader {
+
+  private ConfigReader() {}
+
+  /**
+   * Result of an env/property operation, distinguishing security denial from missing values.
+   */
+  public record ConfigResult(boolean allowed, String value, String message) {
+    public static ConfigResult allowed(String value) {
+      return new ConfigResult(true, value,
+          value != null ? "Read successful" : "Key not found (but access allowed)");
+    }
+
+    public static ConfigResult denied(String reason) {
+      return new ConfigResult(false, null, "DENIED: " + reason);
+    }
+
+    public static ConfigResult writeSuccess(String key, String value) {
+      return new ConfigResult(true, value, "Write successful: " + key + "=" + value);
+    }
+  }
+
+  /**
+   * Reads an environment variable.
+   *
+   * <p>This package is entitled to {@code env.read}, so any env var can be read.
+   *
+   * @param name the environment variable name
+   * @return result indicating whether access was allowed and the value
+   */
+  public static ConfigResult readEnv(String name) {
+    try {
+      String value = System.getenv(name);
+      return ConfigResult.allowed(value);
+    } catch (SecurityException e) {
+      return ConfigResult.denied(e.getMessage());
+    }
+  }
+
+  /**
+   * Writes a system property.
+   *
+   * <p>This package is entitled to {@code system.property.write("app.*")}, so only properties
+   * starting with "app." can be written.
+   *
+   * @param key the property key
+   * @param value the property value
+   * @return result indicating whether write was allowed
+   */
+  public static ConfigResult writeProperty(String key, String value) {
+    try {
+      System.setProperty(key, value);
+      return ConfigResult.writeSuccess(key, value);
+    } catch (SecurityException e) {
+      return ConfigResult.denied(e.getMessage());
+    }
+  }
+
+  /**
+   * Clears a system property.
+   *
+   * <p>Clearing requires write permission for the property.
+   *
+   * @param key the property key to clear
+   * @return result indicating whether clear was allowed
+   */
+  public static ConfigResult clearProperty(String key) {
+    try {
+      System.clearProperty(key);
+      return new ConfigResult(true, null, "Clear successful: " + key);
+    } catch (SecurityException e) {
+      return ConfigResult.denied(e.getMessage());
+    }
+  }
+}


### PR DESCRIPTION
## Description

  Implement three new capabilities for controlling access to environment
  variables and system properties:

  - env.read(pattern?) - controls reading environment variables
  - system.property.read(pattern?) - controls reading system properties
  - system.property.write(pattern?) - controls writing/clearing system properties

  Key features:

  Bulk API gating: Methods like System.getenv(), System.getProperties(),
  and System.setProperties() require no-arg or "*" entitlement. Specific
  patterns like env.read("HOME") do NOT grant bulk access.

  Pattern matching: Supports exact match ("HOME"), single-level wildcard
  ("app.*"), and multi-level wildcard ("app.**") for property hierarchies.

  Reentrancy guard: ThreadLocal-based guard prevents recursion when jGuard
  internals read properties during enforcement.

  Empty pattern validation: Rejects empty patterns ("") in policy files to
  prevent accidental bypass.

  Implementation:
  - Added ENV_READ, PROP_READ, PROP_WRITE operations to Operation.java
  - Created EnvInterceptor and PropertyInterceptor for ByteBuddy advice
  - Updated PolicyEnforcer with bulk gating logic for TARGET_PATTERN category
  - Updated PolicyValidator with signatures and semantic validation
  - Updated BootstrapEnforcer with entry points and fixed ThreadLocal.remove()

  Sandbox demo:
  - Added ConfigReader class demonstrating env.read and property write
  - Policy shows package-scoped env.read and pattern-based property write
  - Demo output shows allowed/blocked access for each capability

  Documentation:
  - Updated README.md, agent/README.md, policy descriptor spec
  - Updated sandbox-demo README with new capabilities

