### PR TITLE
Add community files for open source contributors

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,99 @@
+name: Bug Report
+description: Report a bug or unexpected behavior in jGuard
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the information below to help us investigate.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of what the bug is.
+      placeholder: Describe what happened...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+      placeholder: Describe what you expected...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Minimal steps to reproduce the behavior.
+      placeholder: |
+        1. Create a policy file with...
+        2. Run with agent...
+        3. Call method X...
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: policy
+    attributes:
+      label: Policy File
+      description: Include the relevant `module-info.jguard` policy (if applicable).
+      render: text
+      placeholder: |
+        security module com.example.myapp {
+            entitle module to fs.read("src", "**/*");
+        }
+
+  - type: textarea
+    id: stacktrace
+    attributes:
+      label: Error Output / Stack Trace
+      description: Include any error messages or stack traces.
+      render: text
+
+  - type: input
+    id: jguard-version
+    attributes:
+      label: jGuard Version
+      description: What version of jGuard are you using?
+      placeholder: "0.1.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: java-version
+    attributes:
+      label: Java Version
+      description: What JDK version are you running?
+      options:
+        - "21"
+        - "22"
+        - "23"
+        - "24"
+        - "Other (specify in additional context)"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+        - Linux
+        - macOS
+        - Windows
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security Vulnerability
+    url: https://github.com/lucenia/jguard/security/advisories/new
+    about: Report security vulnerabilities privately (do not use public issues)
+  - name: Questions & Discussions
+    url: https://github.com/lucenia/jguard/discussions
+    about: Ask questions or discuss ideas with the community

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,70 @@
+name: Feature Request
+description: Suggest a new feature or enhancement for jGuard
+title: "[Feature]: "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please describe your idea below.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem does this feature solve? Is it related to a specific use case?
+      placeholder: |
+        I'm trying to... but currently jGuard doesn't support...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like to see.
+      placeholder: |
+        I would like jGuard to support...
+    validations:
+      required: true
+
+  - type: textarea
+    id: policy-example
+    attributes:
+      label: Example Policy Syntax
+      description: If this involves new capabilities, show what the policy syntax might look like.
+      render: text
+      placeholder: |
+        security module com.example.myapp {
+            entitle module to new.capability("arg1", "arg2");
+        }
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Describe any alternative solutions or workarounds you've considered.
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      description: What area of jGuard does this affect?
+      options:
+        - Policy language / syntax
+        - New capability
+        - Agent / enforcement
+        - Gradle plugin
+        - CLI tooling
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      description: Would you be interested in contributing this feature?
+      options:
+        - label: I would be willing to submit a PR for this feature

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**codeofconduct@lucenia.io**.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,95 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.1.x   | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+The jGuard team takes security vulnerabilities seriously. We appreciate your
+efforts to responsibly disclose your findings.
+
+### How to Report
+
+**Please do NOT report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them using one of these methods:
+
+1. **GitHub Private Vulnerability Reporting** (Preferred)
+
+   Use GitHub's private vulnerability reporting feature:
+   [Report a vulnerability](https://github.com/lucenia/jguard/security/advisories/new)
+
+2. **Email**
+
+   Send an email to **security@lucenia.io** with:
+   - A description of the vulnerability
+   - Steps to reproduce the issue
+   - Potential impact assessment
+   - Any suggested fixes (optional)
+
+### What to Expect
+
+- **Acknowledgment**: We will acknowledge receipt of your report within 48 hours.
+- **Initial Assessment**: Within 7 days, we will provide an initial assessment
+  and expected timeline for a fix.
+- **Updates**: We will keep you informed of our progress toward resolving the
+  issue.
+- **Disclosure**: We will coordinate with you on the timing of public disclosure.
+
+### Safe Harbor
+
+We consider security research conducted in accordance with this policy to be:
+
+- Authorized under the Computer Fraud and Abuse Act (CFAA)
+- Exempt from DMCA restrictions on circumvention
+- Lawful and conducted in good faith
+
+We will not pursue legal action against researchers who:
+
+- Act in good faith
+- Avoid privacy violations and data destruction
+- Do not exploit vulnerabilities beyond what is necessary to demonstrate them
+- Report vulnerabilities promptly
+
+### Scope
+
+The following are in scope for security research:
+
+- jGuard core framework
+- jGuard agent
+- Policy compiler and validator
+- Gradle plugin
+
+Out of scope:
+
+- Third-party dependencies (report to upstream maintainers)
+- Social engineering attacks
+- Denial of service attacks
+
+## Security Best Practices for jGuard Users
+
+When using jGuard in production:
+
+1. **Principle of Least Privilege**: Grant only the capabilities each module
+   actually needs.
+
+2. **Review Policies**: Audit your `module-info.jguard` files regularly.
+
+3. **Use Strict Mode**: Run with `-Djguard.mode=strict` in production.
+
+4. **Keep Updated**: Stay current with jGuard releases for security fixes.
+
+5. **External Policies**: Use external policy files in production so you can
+   update entitlements without redeploying:
+   ```bash
+   java -javaagent:jguard-agent.jar=/etc/myapp/policy.bin -jar myapp.jar
+   ```
+
+## Acknowledgments
+
+We gratefully acknowledge security researchers who help improve jGuard.
+Contributors who report valid security issues will be recognized here
+(with permission).


### PR DESCRIPTION
## Description
  Add standard open source community files to support external contributors:

  - CODE_OF_CONDUCT.md: Contributor Covenant v2.1
  - SECURITY.md: Vulnerability reporting process with GitHub private reporting and security@lucenia.io fallback
  - Issue templates: Structured forms for bug reports and feature requests with jGuard-specific fields (policy files, JDK version, etc.)

