### PR TITLE
Add Maven Central and Gradle Plugin Portal publishing

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -131,3 +131,4 @@ For answers to common questions about this code of conduct, see the FAQ at
 [Mozilla CoC]: https://github.com/mozilla/diversity
 [FAQ]: https://www.contributor-covenant.org/faq
 [translations]: https://www.contributor-covenant.org/translations
+

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 
 allprojects {
   group = "io.jguard"
-  version = "0.1.0-SNAPSHOT"
+  version = "0.1.0"
 }
 
 // Spotless configuration (license headers, formatting, linting)
@@ -56,4 +56,74 @@ subprojects {
   // :core -> jguard-core, :policy-java -> jguard-policy-java, etc.
   def moduleName = project.path.substring(1).replace(":", "-")
   archivesBaseName = "jguard-${moduleName}"
+
+  // ---- Maven Central Publishing ----
+  // Skip for gradle-plugin (uses Plugin Portal instead)
+  if (project.name != "gradle-plugin") {
+    apply plugin: "maven-publish"
+    apply plugin: "signing"
+
+    publishing {
+      publications {
+        mavenJava(MavenPublication) {
+          from components.java
+          artifactId = "jguard-${moduleName}"
+
+          pom {
+            name = "jGuard ${project.name.capitalize()}"
+            description = "Capability-based security for the JVM"
+            url = "https://github.com/jguard-io/jguard"
+            inceptionYear = "2025"
+
+            licenses {
+              license {
+                name = "Apache-2.0"
+                url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+              }
+            }
+
+            developers {
+              developer {
+                id = "jguard-contributors"
+                name = "jGuard Contributors"
+                organization = "jGuard"
+                organizationUrl = "https://jguard.io"
+              }
+            }
+
+            scm {
+              connection = "scm:git:git://github.com/jguard-io/jguard.git"
+              developerConnection = "scm:git:ssh://github.com/jguard-io/jguard.git"
+              url = "https://github.com/jguard-io/jguard"
+            }
+          }
+        }
+      }
+
+      repositories {
+        maven {
+          name = "MavenCentral"
+          def releasesUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+          def snapshotsUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+          url = version.endsWith("-SNAPSHOT") ? snapshotsUrl : releasesUrl
+
+          credentials {
+            username = findProperty("ossrhUsername") ?: System.getenv("OSSRH_USERNAME")
+            password = findProperty("ossrhPassword") ?: System.getenv("OSSRH_PASSWORD")
+          }
+        }
+      }
+    }
+
+    signing {
+      // Only sign if credentials are available
+      required { !version.endsWith("-SNAPSHOT") && gradle.taskGraph.hasTask("publish") }
+      def signingKey = findProperty("signingKey") ?: System.getenv("GPG_SIGNING_KEY")
+      def signingPassword = findProperty("signingPassword") ?: System.getenv("GPG_SIGNING_PASSWORD")
+      if (signingKey && signingPassword) {
+        useInMemoryPgpKeys(signingKey, signingPassword)
+      }
+      sign publishing.publications.mavenJava
+    }
+  }
 }

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -7,6 +7,7 @@
 //
 plugins {
   id "java-gradle-plugin"
+  alias(libs.plugins.plugin.publish)
 }
 
 dependencies {
@@ -15,12 +16,16 @@ dependencies {
 }
 
 gradlePlugin {
+  website = "https://github.com/jguard-io/jguard"
+  vcsUrl = "https://github.com/jguard-io/jguard.git"
+
   plugins {
     jguardPolicy {
       id = "io.jguard.policy"
       implementationClass = "io.jguard.gradle.policy.JGuardPolicyPlugin"
-      displayName = "jGuard Policy Compiler"
-      description = "Compiles module-info.jguard into policy metadata and packages it into JARs."
+      displayName = "jGuard Policy Plugin"
+      description = "Compiles jGuard security policies (module-info.jguard) for capability-based JVM security"
+      tags.set(["security", "jguard", "capability", "sandbox", "policy"])
     }
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,4 +36,5 @@ bytebuddy = ["bytebuddy", "bytebuddy-agent"]
 [plugins]
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
+plugin-publish = { id = "com.gradle.plugin-publish", version = "1.3.0" }
 


### PR DESCRIPTION
## Description
  Configure artifact publishing for v0.1.0 release:

  - Add maven-publish and signing plugins for Maven Central
  - Configure POM metadata (license, SCM, developers)
  - Add com.gradle.plugin-publish for Gradle Plugin Portal
  - Support both local GPG agent and CI environment variables
  - Exclude gradle-plugin from Maven Central (uses Plugin Portal)

  Published artifacts:
  - io.jguard:jguard-core
  - io.jguard:jguard-policy
  - io.jguard:jguard-policy-java
  - io.jguard:jguard-agent
  - io.jguard:jguard-agent-bootstrap
  - io.jguard:jguard-cli
  - Plugin: io.jguard.policy (Gradle Plugin Portal)

