### PR TITLE
(feat) Add test-specific policy overrides and multi-directory support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to jGuard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - Unreleased
+
+### Added
+
+- **Test-specific policy overrides**: New `src/test/jguard/` directory support for test-only policies. Test policies extend embedded policies with additional permissions needed during testing (e.g., temp file access, thread creation). Policies are compiled by the `compileTestPolicies` task and automatically passed to the agent during test execution.
+- **Multi-directory policy overrides**: The agent now supports comma-separated paths in `-Djguard.policy.override`, allowing layered policy overrides. Later directories take precedence.
+
+### Fixed
+
+- **Gradle plugin configuration conflict**: Fixed `jguardAgent` configuration creation to use `maybeCreate()` instead of `create()`, avoiding conflicts when other plugins create the configuration first. This was blocking the per-module `module-info.jguard` workflow in multi-module builds.
+- **Embedded policies not discovered during tests**: Fixed policy discovery for tests by outputting compiled policies to `build/jguard-policy/META-INF/jguard/` and registering this directory with `sourceSets.main.output.dir()`. This ensures policies are on the test classpath and properly packaged into JARs.
+- **Gradle cross-project dependency ordering**: Fixed `compileJGuardPolicy` task lifecycle wiring. Policies now output to a dedicated `build/jguard-policy/` directory (avoiding conflicts with `compileJava`'s output), registered via `sourceSets.main.output.dir(builtBy: compileJGuardPolicy)`. This ensures cross-project dependencies (via `project(':other')`) automatically wait for policy compilation.
+- **Directory-based policy discovery**: Fixed agent to discover embedded policies from directories on the classpath, not just JAR files. This enables policy discovery during development/testing when using Gradle class directories (`build/classes/java/main`).
+
 ## [0.3.1] - 2026-01-30
 
 ### Fixed

--- a/agent-bootstrap/src/main/java/io/jguard/bootstrap/AgentConfig.java
+++ b/agent-bootstrap/src/main/java/io/jguard/bootstrap/AgentConfig.java
@@ -8,6 +8,9 @@
 package io.jguard.bootstrap;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Agent configuration parsed from system properties.
@@ -28,7 +31,8 @@ import java.nio.file.Path;
  *   <li><b>jguard.discovery</b> (default: true): Enable embedded policy discovery from JARs
  *   <li><b>jguard.allowUnsignedPolicies</b> (default: false): Allow policies from unsigned JARs
  *   <li><b>jguard.policy.unnamed</b>: Path to policy for unnamed module (classpath code)
- *   <li><b>jguard.policy.override</b>: Path to override directory (can only restrict, not expand)
+ *   <li><b>jguard.policy.override</b>: Path(s) to override directories, comma-separated for
+ *       multiple
  * </ul>
  *
  * <h2>Usage</h2>
@@ -65,7 +69,7 @@ public final class AgentConfig {
   private final boolean discoveryEnabled;
   private final boolean allowUnsignedPolicies;
   private final Path unnamedModulePolicy;
-  private final Path overrideDir;
+  private final List<Path> overrideDirs;
 
   private AgentConfig(Builder builder) {
     this.policyPath = builder.policyPath;
@@ -79,7 +83,7 @@ public final class AgentConfig {
     this.discoveryEnabled = builder.discoveryEnabled;
     this.allowUnsignedPolicies = builder.allowUnsignedPolicies;
     this.unnamedModulePolicy = builder.unnamedModulePolicy;
-    this.overrideDir = builder.overrideDir;
+    this.overrideDirs = Collections.unmodifiableList(new ArrayList<>(builder.overrideDirs));
   }
 
   /**
@@ -131,10 +135,15 @@ public final class AgentConfig {
       builder.unnamedModulePolicy(Path.of(unnamedPolicyStr));
     }
 
-    // Policy override directory
+    // Policy override directories (comma-separated for multiple)
     String overrideDirStr = System.getProperty(PROP_OVERRIDE_DIR);
     if (overrideDirStr != null && !overrideDirStr.isBlank()) {
-      builder.overrideDir(Path.of(overrideDirStr));
+      for (String dir : overrideDirStr.split(",")) {
+        String trimmed = dir.trim();
+        if (!trimmed.isEmpty()) {
+          builder.addOverrideDir(Path.of(trimmed));
+        }
+      }
     }
 
     // Enforcement mode
@@ -292,16 +301,21 @@ public final class AgentConfig {
   }
 
   /**
-   * Returns the path to the external policy directory.
+   * Returns the paths to external policy directories.
    *
-   * <p>When set, the agent loads external policy files from this directory and merges them with
+   * <p>When set, the agent loads external policy files from these directories and merges them with
    * embedded policies using grant/deny semantics:
    *
    * <ul>
    *   <li>Grants from external policies are added to embedded grants (union)
    *   <li>Denials remove capabilities from the effective policy (set difference)
    *   <li>Denials always win over grants
+   *   <li>Later directories take precedence over earlier ones
    * </ul>
+   *
+   * <p>Multiple directories can be specified via comma-separated paths in the system property. This
+   * is useful for layering policies, e.g., production external policies plus test-specific
+   * overrides.
    *
    * <p>Expected directory structure:
    *
@@ -312,10 +326,10 @@ public final class AgentConfig {
    * └── _global.bin                # Global policy (applies to ALL modules)
    * </pre>
    *
-   * @return the external policy directory path, or null if not specified
+   * @return the external policy directory paths, empty list if not specified
    */
-  public Path overrideDir() {
-    return overrideDir;
+  public List<Path> overrideDirs() {
+    return overrideDirs;
   }
 
   @Override
@@ -341,8 +355,8 @@ public final class AgentConfig {
         + allowUnsignedPolicies
         + ", unnamedModulePolicy="
         + unnamedModulePolicy
-        + ", overrideDir="
-        + overrideDir
+        + ", overrideDirs="
+        + overrideDirs
         + '}';
   }
 
@@ -359,7 +373,7 @@ public final class AgentConfig {
     private boolean discoveryEnabled = false;
     private boolean allowUnsignedPolicies = false;
     private Path unnamedModulePolicy;
-    private Path overrideDir;
+    private List<Path> overrideDirs = new ArrayList<>();
 
     /** Creates a new Builder with default values. */
     public Builder() {}
@@ -479,17 +493,34 @@ public final class AgentConfig {
     }
 
     /**
-     * Sets the external policy directory.
+     * Adds an external policy directory.
      *
      * <p>Files in this directory can grant additional capabilities or deny existing capabilities
-     * using grant/deny semantics. See {@link AgentConfig#overrideDir()} for expected directory
-     * structure.
+     * using grant/deny semantics. See {@link AgentConfig#overrideDirs()} for expected directory
+     * structure. Multiple directories can be added; later directories take precedence.
+     *
+     * @param path the external policy directory path
+     * @return this builder
+     */
+    public Builder addOverrideDir(Path path) {
+      this.overrideDirs.add(path);
+      return this;
+    }
+
+    /**
+     * Sets a single external policy directory, clearing any previously added directories.
+     *
+     * <p>This is a convenience method for the common case of a single override directory. For
+     * multiple directories, use {@link #addOverrideDir(Path)}.
      *
      * @param path the external policy directory path
      * @return this builder
      */
     public Builder overrideDir(Path path) {
-      this.overrideDir = path;
+      this.overrideDirs.clear();
+      if (path != null) {
+        this.overrideDirs.add(path);
+      }
       return this;
     }
 

--- a/agent/src/main/java/io/jguard/agent/AgentInitializer.java
+++ b/agent/src/main/java/io/jguard/agent/AgentInitializer.java
@@ -90,10 +90,10 @@ public final class AgentInitializer {
       policy = loadPolicy(config.policyPath());
     }
 
-    // Apply policy overrides if configured
-    if (config.overrideDir() != null) {
-      LOG.info("Applying policy overrides from: {}", config.overrideDir());
-      policy = PolicyMerger.merge(policy, config.overrideDir());
+    // Apply policy overrides if configured (later directories take precedence)
+    for (Path overrideDir : config.overrideDirs()) {
+      LOG.info("Applying policy overrides from: {}", overrideDir);
+      policy = PolicyMerger.merge(policy, overrideDir);
     }
 
     PolicyEnforcer enforcer = new PolicyEnforcer(policy, config);
@@ -110,7 +110,7 @@ public final class AgentInitializer {
     if (config.hotReloadEnabled()) {
       if (config.discoveryEnabled()) {
         // Discovery mode: hot reload external overrides only (base policy is cached)
-        if (config.overrideDir() != null) {
+        if (!config.overrideDirs().isEmpty()) {
           reloader =
               PolicyReloader.forDiscoveryMode(
                   basePolicy, enforcerRef, config, config.hotReloadIntervalSeconds());

--- a/agent/src/main/java/io/jguard/agent/PolicyDiscovery.java
+++ b/agent/src/main/java/io/jguard/agent/PolicyDiscovery.java
@@ -24,20 +24,25 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
 /**
- * Discovers embedded jGuard policies from JARs on the module/class path.
+ * Discovers embedded jGuard policies from JARs and directories on the module/class path.
  *
- * <p>This class scans JARs for embedded policies at {@code META-INF/jguard/policy.bin} and builds
- * an {@link ApplicationPolicy} containing all discovered module policies.
+ * <p>This class scans for embedded policies at {@code META-INF/jguard/policy.bin} in both:
+ *
+ * <ul>
+ *   <li>JAR files (production deployments)
+ *   <li>Directory entries (development/testing with Gradle class directories)
+ * </ul>
  *
  * <h2>Security Model</h2>
  *
  * <p>By default, policies are only loaded from signed JARs. This prevents malicious unsigned code
  * from granting itself capabilities. The {@code jguard.allowUnsignedPolicies} system property can
- * be set to {@code true} for development/testing.
+ * be set to {@code true} for development/testing. Directory-based policies always require this flag
+ * since directories cannot be signed.
  *
  * <h2>Duplicate Detection</h2>
  *
- * <p>If two JARs contain policies for the same module name, discovery fails with a clear error.
+ * <p>If two entries contain policies for the same module name, discovery fails with a clear error.
  * This prevents confusion about which policy applies.
  */
 public final class PolicyDiscovery {
@@ -58,55 +63,18 @@ public final class PolicyDiscovery {
   public static ApplicationPolicy discoverEmbedded(AgentConfig config)
       throws PolicyDiscoveryException {
     List<ModulePolicy> policies = new ArrayList<>();
-    Map<String, String> moduleToJar = new HashMap<>(); // For duplicate detection
+    Map<String, String> moduleToSource = new HashMap<>(); // For duplicate detection
 
+    // Scan JAR files
     List<Path> jarPaths = findJarsOnPath();
     LOG.info("Scanning {} JARs for embedded policies", jarPaths.size());
+    discoverFromJars(config, jarPaths, policies, moduleToSource);
 
-    for (Path jarPath : jarPaths) {
-      try (JarFile jarFile = new JarFile(jarPath.toFile(), true)) { // true = verify signatures
-        if (!JarSignatureVerifier.hasEmbeddedPolicy(jarFile)) {
-          continue;
-        }
-
-        // Check signature (unless unsigned allowed)
-        if (!config.allowUnsignedPolicies()) {
-          if (!JarSignatureVerifier.isSignedAndValid(jarFile)) {
-            LOG.warn(
-                "Skipping unsigned JAR with embedded policy: {}. "
-                    + "Set -Djguard.allowUnsignedPolicies=true for development.",
-                jarPath);
-            continue;
-          }
-        } else {
-          LOG.debug("Allowing unsigned policy from {} (development mode)", jarPath);
-        }
-
-        // Read the embedded policy
-        ModulePolicy policy = readEmbeddedPolicy(jarFile);
-
-        // Check for duplicates
-        String existingJar = moduleToJar.get(policy.moduleName());
-        if (existingJar != null) {
-          throw new PolicyDiscoveryException(
-              String.format(
-                  "Duplicate policy for module '%s' found in:%n  - %s%n  - %s",
-                  policy.moduleName(), existingJar, jarPath));
-        }
-
-        moduleToJar.put(policy.moduleName(), jarPath.toString());
-        policies.add(policy);
-        LOG.info(
-            "Discovered policy for module '{}' from {} ({} entitlements)",
-            policy.moduleName(),
-            jarPath.getFileName(),
-            policy.entitlements().size());
-
-      } catch (IOException e) {
-        LOG.warn("Failed to read JAR {}: {}", jarPath, e.getMessage());
-      } catch (SecurityException e) {
-        LOG.warn("JAR {} failed signature verification: {}", jarPath, e.getMessage());
-      }
+    // Scan directory entries (for development/testing with Gradle class directories)
+    List<Path> dirPaths = findDirectoriesOnPath();
+    if (!dirPaths.isEmpty()) {
+      LOG.info("Scanning {} directories for embedded policies", dirPaths.size());
+      discoverFromDirectories(config, dirPaths, policies, moduleToSource);
     }
 
     // Add unnamed module policy if configured
@@ -123,12 +91,12 @@ public final class PolicyDiscovery {
         }
 
         // Check for duplicates
-        String existingJar = moduleToJar.get(unnamedPolicy.moduleName());
-        if (existingJar != null) {
+        String existingSource = moduleToSource.get(unnamedPolicy.moduleName());
+        if (existingSource != null) {
           throw new PolicyDiscoveryException(
               String.format(
                   "Duplicate policy for module '%s' found in:%n  - %s%n  - %s (external)",
-                  unnamedPolicy.moduleName(), existingJar, config.unnamedModulePolicy()));
+                  unnamedPolicy.moduleName(), existingSource, config.unnamedModulePolicy()));
         }
 
         policies.add(unnamedPolicy);
@@ -153,6 +121,156 @@ public final class PolicyDiscovery {
     }
 
     return ApplicationPolicy.create(policies);
+  }
+
+  /**
+   * Discovers policies from JAR files.
+   *
+   * @param config the agent configuration
+   * @param jarPaths the JAR files to scan
+   * @param policies the list to add discovered policies to
+   * @param moduleToSource map for duplicate detection
+   * @throws PolicyDiscoveryException if a duplicate module is found
+   */
+  private static void discoverFromJars(
+      AgentConfig config,
+      List<Path> jarPaths,
+      List<ModulePolicy> policies,
+      Map<String, String> moduleToSource)
+      throws PolicyDiscoveryException {
+
+    for (Path jarPath : jarPaths) {
+      try (JarFile jarFile = new JarFile(jarPath.toFile(), true)) { // true = verify signatures
+        if (!JarSignatureVerifier.hasEmbeddedPolicy(jarFile)) {
+          continue;
+        }
+
+        // Check signature (unless unsigned allowed)
+        if (!config.allowUnsignedPolicies()) {
+          if (!JarSignatureVerifier.isSignedAndValid(jarFile)) {
+            LOG.warn(
+                "Skipping unsigned JAR with embedded policy: {}. "
+                    + "Set -Djguard.allowUnsignedPolicies=true for development.",
+                jarPath);
+            continue;
+          }
+        } else {
+          LOG.debug("Allowing unsigned policy from {} (development mode)", jarPath);
+        }
+
+        // Read the embedded policy
+        ModulePolicy policy = readEmbeddedPolicy(jarFile);
+
+        // Check for duplicates
+        String existingSource = moduleToSource.get(policy.moduleName());
+        if (existingSource != null) {
+          throw new PolicyDiscoveryException(
+              String.format(
+                  "Duplicate policy for module '%s' found in:%n  - %s%n  - %s",
+                  policy.moduleName(), existingSource, jarPath));
+        }
+
+        moduleToSource.put(policy.moduleName(), jarPath.toString());
+        policies.add(policy);
+        LOG.info(
+            "Discovered policy for module '{}' from {} ({} entitlements)",
+            policy.moduleName(),
+            jarPath.getFileName(),
+            policy.entitlements().size());
+
+      } catch (IOException e) {
+        LOG.warn("Failed to read JAR {}: {}", jarPath, e.getMessage());
+      } catch (SecurityException e) {
+        LOG.warn("JAR {} failed signature verification: {}", jarPath, e.getMessage());
+      }
+    }
+  }
+
+  /**
+   * Discovers policies from directory entries on the classpath.
+   *
+   * <p>This supports development/testing scenarios where Gradle outputs compiled policies to class
+   * directories rather than JARs.
+   *
+   * @param config the agent configuration
+   * @param dirPaths the directories to scan
+   * @param policies the list to add discovered policies to
+   * @param moduleToSource map for duplicate detection
+   * @throws PolicyDiscoveryException if a duplicate module is found
+   */
+  private static void discoverFromDirectories(
+      AgentConfig config,
+      List<Path> dirPaths,
+      List<ModulePolicy> policies,
+      Map<String, String> moduleToSource)
+      throws PolicyDiscoveryException {
+
+    for (Path dirPath : dirPaths) {
+      Path policyFile = dirPath.resolve(JarSignatureVerifier.POLICY_LOCATION);
+      if (!Files.exists(policyFile)) {
+        continue;
+      }
+
+      // Directory-based policies require allowUnsignedPolicies since directories can't be signed
+      if (!config.allowUnsignedPolicies()) {
+        LOG.warn(
+            "Skipping directory-based policy at {}. "
+                + "Set -Djguard.allowUnsignedPolicies=true for development.",
+            policyFile);
+        continue;
+      }
+
+      try {
+        ModulePolicy policy = readPolicyFromDirectory(policyFile);
+
+        // Check for duplicates
+        String existingSource = moduleToSource.get(policy.moduleName());
+        if (existingSource != null) {
+          throw new PolicyDiscoveryException(
+              String.format(
+                  "Duplicate policy for module '%s' found in:%n  - %s%n  - %s",
+                  policy.moduleName(), existingSource, dirPath));
+        }
+
+        moduleToSource.put(policy.moduleName(), dirPath.toString());
+        policies.add(policy);
+        LOG.info(
+            "Discovered policy for module '{}' from directory {} ({} entitlements)",
+            policy.moduleName(),
+            dirPath,
+            policy.entitlements().size());
+
+      } catch (IOException e) {
+        LOG.warn("Failed to read policy from directory {}: {}", dirPath, e.getMessage());
+      }
+    }
+  }
+
+  /**
+   * Reads an embedded policy from a directory (for development/testing).
+   *
+   * @param policyFile the path to the policy.bin file
+   * @return the module policy
+   * @throws IOException if the policy cannot be read
+   */
+  private static ModulePolicy readPolicyFromDirectory(Path policyFile) throws IOException {
+    try (InputStream is = Files.newInputStream(policyFile)) {
+      ApplicationPolicy appPolicy = BinaryPolicyReader.readApplicationPolicy(is);
+
+      // Embedded policies should contain exactly one module
+      if (appPolicy.modules().isEmpty()) {
+        throw new IOException("Policy file contains no modules: " + policyFile);
+      }
+      if (appPolicy.modules().size() > 1) {
+        throw new IOException(
+            "Policy file contains multiple modules ("
+                + appPolicy.modules().size()
+                + "). Each directory should contain policy for one module: "
+                + policyFile);
+      }
+
+      return appPolicy.modules().get(0);
+    }
   }
 
   /**
@@ -259,6 +377,54 @@ public final class PolicyDiscovery {
         } catch (IOException e) {
           LOG.debug("Failed to scan directory {}: {}", path, e.getMessage());
         }
+      }
+    }
+  }
+
+  /**
+   * Finds all directories on the module path and class path.
+   *
+   * <p>This supports development/testing scenarios where classes are in directories rather than
+   * JARs (e.g., Gradle's {@code build/classes/java/main}).
+   *
+   * @return list of directory paths
+   */
+  private static List<Path> findDirectoriesOnPath() {
+    List<Path> dirs = new ArrayList<>();
+
+    // Module path
+    String modulePath = System.getProperty("jdk.module.path");
+    if (modulePath != null && !modulePath.isBlank()) {
+      addDirectoriesFromPath(modulePath, dirs);
+    }
+
+    // Class path
+    String classPath = System.getProperty("java.class.path");
+    if (classPath != null && !classPath.isBlank()) {
+      addDirectoriesFromPath(classPath, dirs);
+    }
+
+    return dirs;
+  }
+
+  /**
+   * Adds directories from a path string to the list.
+   *
+   * @param pathString the path string (colon or semicolon separated)
+   * @param dirs the list to add to
+   */
+  private static void addDirectoriesFromPath(String pathString, List<Path> dirs) {
+    String separator = System.getProperty("path.separator", ":");
+    String[] entries = pathString.split(separator);
+
+    for (String entry : entries) {
+      if (entry.isBlank()) continue;
+
+      Path path = Path.of(entry);
+      if (Files.isDirectory(path)) {
+        // Only add if it's directly a class directory (not a directory containing JARs)
+        // We look for directories that might contain META-INF/jguard/policy.bin
+        dirs.add(path);
       }
     }
   }

--- a/agent/src/main/java/io/jguard/agent/PolicyReloader.java
+++ b/agent/src/main/java/io/jguard/agent/PolicyReloader.java
@@ -142,7 +142,7 @@ public final class PolicyReloader {
       AtomicReference<PolicyEnforcer> enforcerRef,
       AgentConfig config,
       long pollIntervalSeconds) {
-    if (config.overrideDir() == null) {
+    if (config.overrideDirs().isEmpty()) {
       throw new IllegalArgumentException(
           "Hot reload in discovery mode requires an override directory "
               + "(set -Djguard.policy.override=<dir>)");
@@ -186,10 +186,10 @@ public final class PolicyReloader {
   }
 
   private void initializeOverrideDirTimestamp() {
-    Path overrideDir = config.overrideDir();
-    if (overrideDir != null && Files.isDirectory(overrideDir)) {
+    List<Path> overrideDirs = config.overrideDirs();
+    if (!overrideDirs.isEmpty()) {
       try {
-        this.lastOverrideDirModifiedTime = getOverrideDirModifiedTime(overrideDir);
+        this.lastOverrideDirModifiedTime = getOverrideDirsModifiedTime(overrideDirs);
       } catch (IOException e) {
         LOG.warn("Could not read initial override directory timestamp: {}", e.getMessage());
         this.lastOverrideDirModifiedTime = null;
@@ -218,17 +218,17 @@ public final class PolicyReloader {
     scheduler.scheduleAtFixedRate(
         this::checkAndReload, pollIntervalSeconds, pollIntervalSeconds, TimeUnit.SECONDS);
 
-    Path overrideDir = config.overrideDir();
+    List<Path> overrideDirs = config.overrideDirs();
     if (isDiscoveryMode()) {
       LOG.info(
-          "Policy hot reload enabled (discovery mode): watching override directory {} (interval={}s)",
-          overrideDir,
+          "Policy hot reload enabled (discovery mode): watching override directories {} (interval={}s)",
+          overrideDirs,
           pollIntervalSeconds);
-    } else if (overrideDir != null && Files.isDirectory(overrideDir)) {
+    } else if (!overrideDirs.isEmpty()) {
       LOG.info(
-          "Policy hot reload enabled: watching {} and override directory {} (interval={}s)",
+          "Policy hot reload enabled: watching {} and override directories {} (interval={}s)",
           policyPath,
-          overrideDir,
+          overrideDirs,
           pollIntervalSeconds);
     } else {
       LOG.info(
@@ -272,10 +272,10 @@ public final class PolicyReloader {
         }
       }
 
-      // Check if override directory has changed
-      Path overrideDir = config.overrideDir();
-      if (overrideDir != null && Files.isDirectory(overrideDir)) {
-        FileTime currentOverrideModifiedTime = getOverrideDirModifiedTime(overrideDir);
+      // Check if any override directory has changed
+      List<Path> overrideDirs = config.overrideDirs();
+      if (!overrideDirs.isEmpty()) {
+        FileTime currentOverrideModifiedTime = getOverrideDirsModifiedTime(overrideDirs);
         if (lastOverrideDirModifiedTime == null
             || currentOverrideModifiedTime.compareTo(lastOverrideDirModifiedTime) > 0) {
           overridesChanged = true;
@@ -286,13 +286,13 @@ public final class PolicyReloader {
       // Reload if anything changed
       if (policyChanged || overridesChanged) {
         if (isDiscoveryMode()) {
-          LOG.info("Override files changed, reloading from: {}", overrideDir);
+          LOG.info("Override files changed, reloading from: {}", overrideDirs);
         } else if (policyChanged && overridesChanged) {
           LOG.info("Policy and override files changed, reloading");
         } else if (policyChanged) {
           LOG.info("Policy file changed, reloading: {}", policyPath);
         } else {
-          LOG.info("Override files changed, reloading from: {}", overrideDir);
+          LOG.info("Override files changed, reloading from: {}", overrideDirs);
         }
         reload();
       }
@@ -316,10 +316,11 @@ public final class PolicyReloader {
         }
       }
 
-      // Apply overrides if configured
-      Path overrideDir = config.overrideDir();
-      if (overrideDir != null && Files.isDirectory(overrideDir)) {
-        policy = PolicyMerger.merge(policy, overrideDir);
+      // Apply overrides if configured (later directories take precedence)
+      for (Path overrideDir : config.overrideDirs()) {
+        if (Files.isDirectory(overrideDir)) {
+          policy = PolicyMerger.merge(policy, overrideDir);
+        }
       }
 
       // Create new enforcer
@@ -482,7 +483,28 @@ public final class PolicyReloader {
   }
 
   /**
-   * Gets the latest modification time of any .bin file in the override directory.
+   * Gets the latest modification time across all override directories.
+   *
+   * @param overrideDirs the override directories
+   * @return the latest modification time across all directories
+   * @throws IOException if reading any directory fails
+   */
+  private FileTime getOverrideDirsModifiedTime(List<Path> overrideDirs) throws IOException {
+    FileTime latest = null;
+    for (Path overrideDir : overrideDirs) {
+      if (Files.isDirectory(overrideDir)) {
+        FileTime dirTime = getOverrideDirModifiedTime(overrideDir);
+        if (latest == null || dirTime.compareTo(latest) > 0) {
+          latest = dirTime;
+        }
+      }
+    }
+    // If no directories exist yet, use epoch
+    return latest != null ? latest : FileTime.fromMillis(0);
+  }
+
+  /**
+   * Gets the latest modification time of any .bin file in a single override directory.
    *
    * @param overrideDir the override directory
    * @return the latest modification time

--- a/agent/src/test/java/io/jguard/agent/AgentConfigTest.java
+++ b/agent/src/test/java/io/jguard/agent/AgentConfigTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.jguard.bootstrap.AgentConfig;
 import io.jguard.bootstrap.EnforcementMode;
+import java.nio.file.Path;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -93,6 +94,68 @@ class AgentConfigTest {
     void canBeSetToFalse() {
       AgentConfig config = builder().logDenied(false).build();
       assertThat(config.logDenied()).isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("overrideDirs()")
+  class OverrideDirsTests {
+
+    @Test
+    @DisplayName("defaults to empty list")
+    void defaultsToEmptyList() {
+      AgentConfig config = builder().build();
+      assertThat(config.overrideDirs()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("single directory via overrideDir()")
+    void singleDirectoryViaOverrideDir() {
+      AgentConfig config = builder().overrideDir(Path.of("/etc/policies")).build();
+      assertThat(config.overrideDirs()).containsExactly(Path.of("/etc/policies"));
+    }
+
+    @Test
+    @DisplayName("multiple directories via addOverrideDir()")
+    void multipleDirectoriesViaAddOverrideDir() {
+      AgentConfig config =
+          builder()
+              .addOverrideDir(Path.of("/etc/policies"))
+              .addOverrideDir(Path.of("/app/test-policies"))
+              .build();
+      assertThat(config.overrideDirs())
+          .containsExactly(Path.of("/etc/policies"), Path.of("/app/test-policies"));
+    }
+
+    @Test
+    @DisplayName("overrideDir() clears previously added directories")
+    void overrideDirClearsPreviouslyAdded() {
+      AgentConfig config =
+          builder()
+              .addOverrideDir(Path.of("/first"))
+              .addOverrideDir(Path.of("/second"))
+              .overrideDir(Path.of("/only"))
+              .build();
+      assertThat(config.overrideDirs()).containsExactly(Path.of("/only"));
+    }
+
+    @Test
+    @DisplayName("overrideDir(null) clears all directories")
+    void overrideDirNullClearsAll() {
+      AgentConfig config =
+          builder()
+              .addOverrideDir(Path.of("/first"))
+              .addOverrideDir(Path.of("/second"))
+              .overrideDir(null)
+              .build();
+      assertThat(config.overrideDirs()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("list is immutable")
+    void listIsImmutable() {
+      AgentConfig config = builder().addOverrideDir(Path.of("/etc/policies")).build();
+      assertThat(config.overrideDirs()).isUnmodifiable();
     }
   }
 }

--- a/agent/src/test/java/io/jguard/agent/MultiModuleHotReloadTest.java
+++ b/agent/src/test/java/io/jguard/agent/MultiModuleHotReloadTest.java
@@ -490,6 +490,123 @@ class MultiModuleHotReloadTest {
     }
   }
 
+  @Nested
+  @DisplayName("Multiple override directories")
+  class MultipleOverrideDirectories {
+
+    private Path overrideDir2;
+
+    @BeforeEach
+    void setUpSecondDir() throws IOException {
+      overrideDir2 = tempDir.resolve("overrides2");
+      Files.createDirectories(overrideDir2);
+    }
+
+    @Test
+    @DisplayName("later directories take precedence")
+    void laterDirectoriesTakePrecedence() throws Exception {
+      // Create base policy with no capabilities
+      ModulePolicy baseModule = new ModulePolicy("com.example.app", List.of(), List.of());
+      ApplicationPolicy basePolicy = ApplicationPolicy.single(baseModule);
+      writePolicyFile(policyPath, basePolicy);
+
+      // First override grants fs.read
+      ModulePolicy override1 =
+          new ModulePolicy(
+              "com.example.app",
+              List.of(new Entitlement(SubjectPattern.module(), createCapability("fs.read"))),
+              List.of());
+      writeExternalPolicyTo(overrideDir, "com.example.app.bin", override1);
+
+      // Second override denies fs.read
+      ModulePolicy override2 =
+          new ModulePolicy(
+              "com.example.app",
+              List.of(),
+              List.of(new Denial(SubjectPattern.module(), createCapability("fs.read"), false)));
+      writeExternalPolicyTo(overrideDir2, "com.example.app.bin", override2);
+
+      // Build config with both directories (override2 listed second = takes precedence)
+      config =
+          new AgentConfig.Builder()
+              .policyPath(policyPath)
+              .mode(EnforcementMode.STRICT)
+              .addOverrideDir(overrideDir)
+              .addOverrideDir(overrideDir2)
+              .build();
+
+      // Merge policies in order
+      ApplicationPolicy merged = basePolicy;
+      merged = PolicyMerger.merge(merged, overrideDir);
+      merged = PolicyMerger.merge(merged, overrideDir2);
+
+      PolicyEnforcer enforcer = new PolicyEnforcer(merged, config);
+      enforcerRef = new AtomicReference<>(enforcer);
+
+      // The denial from overrideDir2 should take precedence
+      assertModuleDoesNotHaveCapability("com.example.app", "fs.read");
+    }
+
+    @Test
+    @DisplayName("changes to any directory trigger reload")
+    void changesToAnyDirectoryTriggerReload() throws Exception {
+      // Create base policy
+      ModulePolicy baseModule =
+          new ModulePolicy(
+              "com.example.app",
+              List.of(new Entitlement(SubjectPattern.module(), createCapability("fs.read"))),
+              List.of());
+      ApplicationPolicy basePolicy = ApplicationPolicy.single(baseModule);
+
+      // Build config with both directories
+      config =
+          new AgentConfig.Builder()
+              .discoveryEnabled(true)
+              .mode(EnforcementMode.STRICT)
+              .addOverrideDir(overrideDir)
+              .addOverrideDir(overrideDir2)
+              .build();
+
+      // Start with merged policy
+      ApplicationPolicy merged = PolicyMerger.merge(basePolicy, overrideDir);
+      merged = PolicyMerger.merge(merged, overrideDir2);
+      PolicyEnforcer enforcer = new PolicyEnforcer(merged, config);
+      enforcerRef = new AtomicReference<>(enforcer);
+
+      reloader = PolicyReloader.forDiscoveryMode(basePolicy, enforcerRef, config, 1);
+      reloader.start();
+
+      // Verify initial state
+      assertModuleHasCapability("com.example.app", "fs.read");
+      assertModuleDoesNotHaveCapability("com.example.app", "threads.create");
+
+      Thread.sleep(100);
+
+      // Add a policy to the SECOND directory (should trigger reload)
+      ModulePolicy newOverride =
+          new ModulePolicy(
+              "com.example.app",
+              List.of(new Entitlement(SubjectPattern.module(), createCapability("threads.create"))),
+              List.of());
+      writeExternalPolicyTo(overrideDir2, "com.example.app.bin", newOverride);
+
+      Thread.sleep(2000);
+
+      // New capability should be available
+      assertModuleHasCapability("com.example.app", "fs.read");
+      assertModuleHasCapability("com.example.app", "threads.create");
+    }
+
+    private void writeExternalPolicyTo(Path dir, String filename, ModulePolicy policy)
+        throws IOException {
+      Path policyPath = dir.resolve(filename);
+      ApplicationPolicy appPolicy = ApplicationPolicy.single(policy);
+      try (FileOutputStream fos = new FileOutputStream(policyPath.toFile())) {
+        BinaryPolicyWriter.write(appPolicy, fos);
+      }
+    }
+  }
+
   // ===== Helper methods =====
 
   private ModulePolicy createModule(String name, String... capabilities) {

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 
 allprojects {
   group = "io.jguard"
-  version = "0.3.1"
+  version = "0.4.0-SNAPSHOT"
 }
 
 // Spotless configuration (license headers, formatting, linting)

--- a/gradle-plugin/src/main/java/io/jguard/gradle/policy/JGuardPolicyExtension.java
+++ b/gradle-plugin/src/main/java/io/jguard/gradle/policy/JGuardPolicyExtension.java
@@ -172,6 +172,41 @@ public abstract class JGuardPolicyExtension {
   public abstract Property<Boolean> getExternalPoliciesIncludeJson();
 
   // ========================================================================
+  // Test Policies Configuration
+  // ========================================================================
+
+  /**
+   * The source directory containing test-specific policy {@code .jguard} files.
+   *
+   * <p>Test policies extend embedded policies with additional permissions needed during testing
+   * (e.g., temp file access, thread creation for test frameworks). These policies are only applied
+   * when running tests, not in production.
+   *
+   * <p>All {@code *.jguard} files in this directory will be compiled to binary format and passed to
+   * the agent during test execution.
+   *
+   * <p>Default: {@code src/test/jguard}
+   *
+   * <p>Example usage:
+   *
+   * <pre>
+   * // File: src/test/jguard/io.mymodule.jguard
+   * security module io.mymodule {
+   *     entitle io.mymodule.. to fs.write("/tmp", "**");
+   *     entitle io.mymodule.. to threads.create;
+   * }
+   * </pre>
+   */
+  public abstract DirectoryProperty getTestPoliciesSourceDir();
+
+  /**
+   * The output directory for compiled test policy {@code .bin} files.
+   *
+   * <p>Default: {@code build/test-policies/}
+   */
+  public abstract DirectoryProperty getTestPoliciesOutputDir();
+
+  // ========================================================================
   // Trusted Module Configuration
   // ========================================================================
 

--- a/gradle-plugin/src/main/java/io/jguard/gradle/policy/JGuardPolicyPlugin.java
+++ b/gradle-plugin/src/main/java/io/jguard/gradle/policy/JGuardPolicyPlugin.java
@@ -10,6 +10,7 @@ package io.jguard.gradle.policy;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
@@ -20,6 +21,7 @@ import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.testing.Test;
@@ -44,6 +46,7 @@ public class JGuardPolicyPlugin implements Plugin<Project> {
   public static final String EXTENSION_NAME = "jguardPolicy";
   public static final String TASK_NAME = "compileJGuardPolicy";
   public static final String EXTERNAL_POLICIES_TASK_NAME = "compileExternalPolicies";
+  public static final String TEST_POLICIES_TASK_NAME = "compileTestPolicies";
   public static final String AGENT_CONFIGURATION_NAME = "jguardAgent";
   public static final String RUN_WITH_AGENT_TASK_NAME = "runWithAgent";
 
@@ -134,33 +137,83 @@ public class JGuardPolicyPlugin implements Plugin<Project> {
                   });
             });
 
+    // Register the test policies compile task
+    project
+        .getTasks()
+        .register(
+            TEST_POLICIES_TASK_NAME,
+            CompileExternalPoliciesTask.class,
+            task -> {
+              task.setDescription(
+                  "Compiles test-specific policy .jguard files from src/test/jguard");
+              task.setGroup("jguard");
+
+              // Wire inputs from extension
+              task.getSourceDir().set(extension.getTestPoliciesSourceDir());
+              task.getOutputDir().set(extension.getTestPoliciesOutputDir());
+              task.getIncludeJson().set(false); // Never need JSON for test policies
+
+              // Wire source files for proper up-to-date tracking
+              task.getSourceFiles()
+                  .from(
+                      project.provider(
+                          () -> {
+                            if (extension.getTestPoliciesSourceDir().isPresent()) {
+                              return extension
+                                  .getTestPoliciesSourceDir()
+                                  .get()
+                                  .getAsFileTree()
+                                  .matching(pattern -> pattern.include("*.jguard"));
+                            }
+                            return project.files();
+                          }));
+
+              // Only enable task if source dir exists and has files
+              task.onlyIf(
+                  t -> {
+                    if (!extension.getTestPoliciesSourceDir().isPresent()) {
+                      return false;
+                    }
+                    File sourceDir = extension.getTestPoliciesSourceDir().get().getAsFile();
+                    return sourceDir.exists() && sourceDir.isDirectory();
+                  });
+            });
+
     // Integrate with jar task if Java plugin is applied
     project
         .getPlugins()
         .withType(
             JavaPlugin.class,
             javaPlugin -> {
+              // Wire compileJGuardPolicy into the build lifecycle.
+              // The policy outputs to build/classes/java/main/META-INF/jguard/
+              // which is a shared output directory with compileJava.
+
+              // 1. compileJGuardPolicy must run after compileJava (same project)
+              compileTask.configure(task -> task.dependsOn(JavaPlugin.COMPILE_JAVA_TASK_NAME));
+
+              // 2. Register policy output as part of main source set output.
+              //    This tells Gradle that any consumer of this source set (via project
+              //    dependencies) must wait for compileJGuardPolicy. Without this, cross-project
+              //    dependencies would not know about the policy compilation task.
+              //    We register build/jguard-policy (the parent), not the full path, so that
+              //    META-INF/jguard/policy.bin structure is preserved in the JAR.
+              SourceSetContainer sourceSets =
+                  project.getExtensions().getByType(SourceSetContainer.class);
+              SourceSet mainSourceSet = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME);
+              Provider<Directory> policyRootDir =
+                  project.getLayout().getBuildDirectory().dir("jguard-policy");
+              mainSourceSet.getOutput().dir(Map.of("builtBy", compileTask), policyRootDir);
+
+              // 3. The 'classes' task must depend on compileJGuardPolicy
               project
                   .getTasks()
-                  .named(
-                      JavaPlugin.JAR_TASK_NAME,
-                      Jar.class,
-                      jar -> {
-                        jar.dependsOn(compileTask);
+                  .named(JavaPlugin.CLASSES_TASK_NAME, task -> task.dependsOn(compileTask));
 
-                        // Only include outputs if the source file exists
-                        jar.from(
-                            compileTask.flatMap(
-                                task -> {
-                                  if (task.getSourceFile().get().getAsFile().exists()) {
-                                    return extension.getOutputDir();
-                                  }
-                                  return project.provider(() -> project.files());
-                                }),
-                            spec -> {
-                              spec.into(extension.getJarPath());
-                            });
-                      });
+              // 4. JAR task also depends on compileJGuardPolicy (belt and suspenders)
+              project
+                  .getTasks()
+                  .named(JavaPlugin.JAR_TASK_NAME, Jar.class, jar -> jar.dependsOn(compileTask));
 
               // Only configure module path inference for modular projects (those with
               // module-info.java).
@@ -237,20 +290,23 @@ public class JGuardPolicyPlugin implements Plugin<Project> {
                         });
               }
 
-              // Wire test tasks to depend on external policies compilation.
-              // External policies are commonly used for test infrastructure (Gradle workers,
-              // JUnit, JaCoCo, etc.), so tests should automatically compile them first.
-              TaskProvider<CompileExternalPoliciesTask> externalPoliciesTaskProvider =
-                  project
-                      .getTasks()
-                      .named(EXTERNAL_POLICIES_TASK_NAME, CompileExternalPoliciesTask.class);
-
+              // Wire test tasks to depend on policy compilation.
+              // Embedded policies are output to build/classes/java/main/META-INF/jguard/
+              // so they must be compiled before tests run.
               project
                   .getTasks()
                   .withType(
                       Test.class,
                       task -> {
-                        // Only add dependency if external policies source dir is configured
+                        // Depend on embedded policy compilation
+                        task.dependsOn(compileTask);
+
+                        // Also depend on external policies if configured
+                        TaskProvider<CompileExternalPoliciesTask> externalPoliciesTaskProvider =
+                            project
+                                .getTasks()
+                                .named(
+                                    EXTERNAL_POLICIES_TASK_NAME, CompileExternalPoliciesTask.class);
                         task.dependsOn(
                             project.provider(
                                 () -> {
@@ -263,6 +319,59 @@ public class JGuardPolicyPlugin implements Plugin<Project> {
                                   }
                                   return project.files(); // Empty dependency if not configured
                                 }));
+
+                        // Also depend on test policies if configured
+                        TaskProvider<CompileExternalPoliciesTask> testPoliciesTaskProvider =
+                            project
+                                .getTasks()
+                                .named(TEST_POLICIES_TASK_NAME, CompileExternalPoliciesTask.class);
+                        task.dependsOn(
+                            project.provider(
+                                () -> {
+                                  if (extension.getTestPoliciesSourceDir().isPresent()) {
+                                    File sourceDir =
+                                        extension.getTestPoliciesSourceDir().get().getAsFile();
+                                    if (sourceDir.exists() && sourceDir.isDirectory()) {
+                                      return testPoliciesTaskProvider;
+                                    }
+                                  }
+                                  return project.files(); // Empty dependency if not configured
+                                }));
+
+                        // Configure JVM args to pass override directories
+                        // The agent supports comma-separated directories for layered overrides
+                        task.doFirst(
+                            t -> {
+                              List<String> overrideDirs = new ArrayList<>();
+
+                              // Add external policies dir if configured
+                              if (extension.getExternalPoliciesSourceDir().isPresent()) {
+                                File sourceDir =
+                                    extension.getExternalPoliciesSourceDir().get().getAsFile();
+                                if (sourceDir.exists() && sourceDir.isDirectory()) {
+                                  File outputDir =
+                                      extension.getExternalPoliciesOutputDir().get().getAsFile();
+                                  overrideDirs.add(outputDir.getAbsolutePath());
+                                }
+                              }
+
+                              // Add test policies dir if configured (takes precedence)
+                              if (extension.getTestPoliciesSourceDir().isPresent()) {
+                                File sourceDir =
+                                    extension.getTestPoliciesSourceDir().get().getAsFile();
+                                if (sourceDir.exists() && sourceDir.isDirectory()) {
+                                  File outputDir =
+                                      extension.getTestPoliciesOutputDir().get().getAsFile();
+                                  overrideDirs.add(outputDir.getAbsolutePath());
+                                }
+                              }
+
+                              // Pass comma-separated override directories to agent
+                              if (!overrideDirs.isEmpty()) {
+                                String overridePath = String.join(",", overrideDirs);
+                                task.jvmArgs("-Djguard.policy.override=" + overridePath);
+                              }
+                            });
                       });
             });
 
@@ -275,16 +384,13 @@ public class JGuardPolicyPlugin implements Plugin<Project> {
   }
 
   private Configuration createAgentConfiguration(Project project) {
-    return project
-        .getConfigurations()
-        .create(
-            AGENT_CONFIGURATION_NAME,
-            config -> {
-              config.setDescription("jGuard agent JAR for runtime enforcement");
-              config.setCanBeConsumed(false);
-              config.setCanBeResolved(true);
-              config.setVisible(false);
-            });
+    // Use maybeCreate to avoid conflicts when other plugins create this configuration first
+    Configuration config = project.getConfigurations().maybeCreate(AGENT_CONFIGURATION_NAME);
+    config.setDescription("jGuard agent JAR for runtime enforcement");
+    config.setCanBeConsumed(false);
+    config.setCanBeResolved(true);
+    config.setVisible(false);
+    return config;
   }
 
   private void registerRunWithAgentTask(
@@ -560,9 +666,21 @@ public class JGuardPolicyPlugin implements Plugin<Project> {
         .getSourceFile()
         .convention(
             project.getLayout().getProjectDirectory().file("src/main/java/module-info.jguard"));
+    // Output to a separate directory (not build/classes/java/main) to avoid
+    // Gradle task ownership conflicts. The directory is registered with
+    // sourceSets.main.output.dir() so it's included in:
+    // 1. Test classpath (for test-time policy discovery)
+    // 2. JAR packaging (policy ends up at META-INF/jguard/policy.bin)
+    // 3. Cross-project dependency resolution
+    // Use flatMap for lazy evaluation - jarPath may not be set for external-only builds
     extension
         .getOutputDir()
-        .convention(project.getLayout().getBuildDirectory().dir("generated/jguard"));
+        .convention(
+            extension
+                .getJarPath()
+                .flatMap(
+                    jarPath ->
+                        project.getLayout().getBuildDirectory().dir("jguard-policy/" + jarPath)));
     // JSON output disabled by default since Jackson is excluded from plugin dependencies
     // to avoid JPMS conflicts in Gradle buildSrc. Enable with includeJson = true if Jackson
     // is available on the classpath.
@@ -581,6 +699,14 @@ public class JGuardPolicyPlugin implements Plugin<Project> {
         .getExternalPoliciesOutputDir()
         .convention(project.getLayout().getBuildDirectory().dir("external-policies"));
     extension.getExternalPoliciesIncludeJson().convention(false);
+
+    // Test policies defaults
+    extension
+        .getTestPoliciesSourceDir()
+        .convention(project.getLayout().getProjectDirectory().dir("src/test/jguard"));
+    extension
+        .getTestPoliciesOutputDir()
+        .convention(project.getLayout().getBuildDirectory().dir("test-policies"));
 
     // Trusted module defaults
     extension.getAllowTrusted().convention(false);


### PR DESCRIPTION
## Description

Agent changes:
- AgentConfig now supports multiple override directories via comma-separated -Djguard.policy.override=dir1,dir2 (later directories take precedence)
- PolicyReloader watches all override directories for hot reload
- PolicyDiscovery scans directories on classpath, not just JARs

Gradle plugin changes:
- Add compileTestPolicies task for src/test/jguard/*.jguard files
- Test tasks automatically pass both external and test policy directories
- Default testPoliciesSourceDir: src/test/jguard
- Default testPoliciesOutputDir: build/test-policies

This enables clean separation of concerns:
- src/main/java/module-info.jguard → Production policy (minimal)
- src/test/jguard/*.jguard → Module-specific test extensions
- buildSrc external policies → Third-party libraries
