### PR TITLE
(feat) Add embedded external policies for third-party dependency support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Test-specific policy overrides**: New `src/test/jguard/` directory support for test-only policies. Test policies extend embedded policies with additional permissions needed during testing (e.g., temp file access, thread creation). Policies are compiled by the `compileTestPolicies` task and automatically passed to the agent during test execution.
 - **Multi-directory policy overrides**: The agent now supports comma-separated paths in `-Djguard.policy.override`, allowing layered policy overrides. Later directories take precedence.
+- **Embedded external policies**: Modules can now ship policies for third-party dependencies by placing them in `src/main/jguard/`. These policies are compiled to `META-INF/jguard/external/*.bin` in the JAR and automatically discovered by the agent alongside embedded policies. This enables applications to define capabilities for runtime dependencies (e.g., Netty, Reactor) without requiring manual `-Djguard.policy.override` configuration. Same signing requirements apply as embedded policies.
 
 ### Fixed
 

--- a/agent/src/main/java/io/jguard/agent/JarSignatureVerifier.java
+++ b/agent/src/main/java/io/jguard/agent/JarSignatureVerifier.java
@@ -36,6 +36,9 @@ public final class JarSignatureVerifier {
   /** Standard location for embedded jGuard policies. */
   public static final String POLICY_LOCATION = "META-INF/jguard/policy.bin";
 
+  /** Standard location for external policies (third-party library policies). */
+  public static final String EXTERNAL_POLICIES_DIR = "META-INF/jguard/external";
+
   private JarSignatureVerifier() {
     // Static utility class
   }
@@ -48,6 +51,28 @@ public final class JarSignatureVerifier {
    */
   public static boolean hasEmbeddedPolicy(JarFile jarFile) {
     return jarFile.getEntry(POLICY_LOCATION) != null;
+  }
+
+  /**
+   * Finds all external policy entries in a JAR file.
+   *
+   * <p>External policies are located at {@code META-INF/jguard/external/*.bin} and provide policies
+   * for third-party libraries that don't ship with their own policies.
+   *
+   * @param jarFile the JAR file to scan
+   * @return list of entry names for external policy files (empty if none found)
+   */
+  public static java.util.List<String> findExternalPolicyEntries(JarFile jarFile) {
+    java.util.List<String> entries = new java.util.ArrayList<>();
+    Enumeration<JarEntry> jarEntries = jarFile.entries();
+    while (jarEntries.hasMoreElements()) {
+      JarEntry entry = jarEntries.nextElement();
+      String name = entry.getName();
+      if (name.startsWith(EXTERNAL_POLICIES_DIR + "/") && name.endsWith(".bin")) {
+        entries.add(name);
+      }
+    }
+    return entries;
   }
 
   /**
@@ -104,7 +129,7 @@ public final class JarSignatureVerifier {
    * @param jarFile the JAR file to check
    * @return true if the JAR has at least one .SF signature file
    */
-  private static boolean hasSignatures(JarFile jarFile) {
+  public static boolean hasSignatures(JarFile jarFile) {
     Enumeration<JarEntry> entries = jarFile.entries();
     while (entries.hasMoreElements()) {
       JarEntry entry = entries.nextElement();
@@ -114,6 +139,26 @@ public final class JarSignatureVerifier {
       }
     }
     return false;
+  }
+
+  /**
+   * Verifies that a specific JAR entry by name is signed.
+   *
+   * @param jarFile the JAR file
+   * @param entryName the name of the entry to verify
+   * @return true if the entry is signed and the signature is valid
+   */
+  public static boolean isEntrySigned(JarFile jarFile, String entryName) {
+    JarEntry entry = jarFile.getJarEntry(entryName);
+    if (entry == null) {
+      return false;
+    }
+    try {
+      return verifyEntry(jarFile, entry);
+    } catch (IOException e) {
+      LOG.debug("Failed to verify entry {}: {}", entryName, e.getMessage());
+      return false;
+    }
   }
 
   /**

--- a/agent/src/main/java/io/jguard/agent/PolicyDiscovery.java
+++ b/agent/src/main/java/io/jguard/agent/PolicyDiscovery.java
@@ -14,6 +14,7 @@ import io.jguard.policy.model.ModulePolicy;
 import io.jguard.policy.serialization.BinaryPolicyReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -26,12 +27,20 @@ import java.util.jar.JarFile;
 /**
  * Discovers embedded jGuard policies from JARs and directories on the module/class path.
  *
- * <p>This class scans for embedded policies at {@code META-INF/jguard/policy.bin} in both:
+ * <p>This class scans for policies at:
  *
  * <ul>
- *   <li>JAR files (production deployments)
- *   <li>Directory entries (development/testing with Gradle class directories)
+ *   <li>{@code META-INF/jguard/policy.bin} - Embedded policy for the module itself
+ *   <li>{@code META-INF/jguard/external/*.bin} - External policies for third-party libraries
  * </ul>
+ *
+ * <p>Both JAR files (production) and directories (development/testing) are scanned.
+ *
+ * <h2>External Policies</h2>
+ *
+ * <p>External policies allow modules to ship policies for their runtime dependencies (e.g., Netty,
+ * Reactor, Jackson) that don't have native jGuard support. When a module's JAR contains external
+ * policies, they are automatically discovered and applied to the named modules.
  *
  * <h2>Security Model</h2>
  *
@@ -126,6 +135,13 @@ public final class PolicyDiscovery {
   /**
    * Discovers policies from JAR files.
    *
+   * <p>This method scans each JAR for:
+   *
+   * <ul>
+   *   <li>Embedded policy at {@code META-INF/jguard/policy.bin}
+   *   <li>External policies at {@code META-INF/jguard/external/*.bin}
+   * </ul>
+   *
    * @param config the agent configuration
    * @param jarPaths the JAR files to scan
    * @param policies the list to add discovered policies to
@@ -141,42 +157,98 @@ public final class PolicyDiscovery {
 
     for (Path jarPath : jarPaths) {
       try (JarFile jarFile = new JarFile(jarPath.toFile(), true)) { // true = verify signatures
-        if (!JarSignatureVerifier.hasEmbeddedPolicy(jarFile)) {
+        boolean hasEmbedded = JarSignatureVerifier.hasEmbeddedPolicy(jarFile);
+        List<String> externalEntries = JarSignatureVerifier.findExternalPolicyEntries(jarFile);
+
+        if (!hasEmbedded && externalEntries.isEmpty()) {
           continue;
         }
 
         // Check signature (unless unsigned allowed)
+        boolean isSignedJar = true;
         if (!config.allowUnsignedPolicies()) {
-          if (!JarSignatureVerifier.isSignedAndValid(jarFile)) {
-            LOG.warn(
-                "Skipping unsigned JAR with embedded policy: {}. "
-                    + "Set -Djguard.allowUnsignedPolicies=true for development.",
-                jarPath);
+          if (!JarSignatureVerifier.hasSignatures(jarFile)) {
+            if (hasEmbedded) {
+              LOG.warn(
+                  "Skipping unsigned JAR with embedded policy: {}. "
+                      + "Set -Djguard.allowUnsignedPolicies=true for development.",
+                  jarPath);
+            }
+            if (!externalEntries.isEmpty()) {
+              LOG.warn(
+                  "Skipping {} external policies from unsigned JAR: {}. "
+                      + "Set -Djguard.allowUnsignedPolicies=true for development.",
+                  externalEntries.size(),
+                  jarPath);
+            }
             continue;
           }
+          isSignedJar = true;
         } else {
-          LOG.debug("Allowing unsigned policy from {} (development mode)", jarPath);
+          LOG.debug("Allowing unsigned policies from {} (development mode)", jarPath);
+          isSignedJar = false;
         }
 
-        // Read the embedded policy
-        ModulePolicy policy = readEmbeddedPolicy(jarFile);
+        // Discover embedded policy
+        if (hasEmbedded) {
+          // Verify signature on the embedded policy entry
+          if (isSignedJar && !config.allowUnsignedPolicies()) {
+            if (!JarSignatureVerifier.isEntrySigned(
+                jarFile, JarSignatureVerifier.POLICY_LOCATION)) {
+              LOG.warn("JAR {} embedded policy entry is not signed", jarPath);
+              continue;
+            }
+          }
 
-        // Check for duplicates
-        String existingSource = moduleToSource.get(policy.moduleName());
-        if (existingSource != null) {
-          throw new PolicyDiscoveryException(
-              String.format(
-                  "Duplicate policy for module '%s' found in:%n  - %s%n  - %s",
-                  policy.moduleName(), existingSource, jarPath));
+          ModulePolicy policy = readEmbeddedPolicy(jarFile);
+
+          // Check for duplicates
+          String existingSource = moduleToSource.get(policy.moduleName());
+          if (existingSource != null) {
+            throw new PolicyDiscoveryException(
+                String.format(
+                    "Duplicate policy for module '%s' found in:%n  - %s%n  - %s",
+                    policy.moduleName(), existingSource, jarPath));
+          }
+
+          moduleToSource.put(policy.moduleName(), jarPath.toString());
+          policies.add(policy);
+          LOG.info(
+              "Discovered policy for module '{}' from {} ({} entitlements)",
+              policy.moduleName(),
+              jarPath.getFileName(),
+              policy.entitlements().size());
         }
 
-        moduleToSource.put(policy.moduleName(), jarPath.toString());
-        policies.add(policy);
-        LOG.info(
-            "Discovered policy for module '{}' from {} ({} entitlements)",
-            policy.moduleName(),
-            jarPath.getFileName(),
-            policy.entitlements().size());
+        // Discover external policies
+        for (String entryName : externalEntries) {
+          // Verify signature on each external policy entry
+          if (isSignedJar && !config.allowUnsignedPolicies()) {
+            if (!JarSignatureVerifier.isEntrySigned(jarFile, entryName)) {
+              LOG.warn("JAR {} external policy entry {} is not signed", jarPath, entryName);
+              continue;
+            }
+          }
+
+          ModulePolicy policy = readExternalPolicy(jarFile, entryName);
+
+          // Check for duplicates
+          String existingSource = moduleToSource.get(policy.moduleName());
+          if (existingSource != null) {
+            throw new PolicyDiscoveryException(
+                String.format(
+                    "Duplicate policy for module '%s' found in:%n  - %s%n  - %s (external)",
+                    policy.moduleName(), existingSource, jarPath));
+          }
+
+          moduleToSource.put(policy.moduleName(), jarPath.toString() + "!" + entryName);
+          policies.add(policy);
+          LOG.info(
+              "Discovered external policy for module '{}' from {} ({} entitlements)",
+              policy.moduleName(),
+              jarPath.getFileName(),
+              policy.entitlements().size());
+        }
 
       } catch (IOException e) {
         LOG.warn("Failed to read JAR {}: {}", jarPath, e.getMessage());
@@ -187,10 +259,45 @@ public final class PolicyDiscovery {
   }
 
   /**
+   * Reads an external policy from a JAR file.
+   *
+   * @param jarFile the JAR file containing the policy
+   * @param entryName the name of the entry (e.g., META-INF/jguard/external/io.netty.common.bin)
+   * @return the module policy
+   * @throws IOException if the policy cannot be read
+   */
+  private static ModulePolicy readExternalPolicy(JarFile jarFile, String entryName)
+      throws IOException {
+    JarEntry entry = jarFile.getJarEntry(entryName);
+    if (entry == null) {
+      throw new IOException("No policy found at " + entryName);
+    }
+
+    try (InputStream is = jarFile.getInputStream(entry)) {
+      ApplicationPolicy appPolicy = BinaryPolicyReader.readApplicationPolicy(is);
+
+      // External policies should contain exactly one module
+      if (appPolicy.modules().isEmpty()) {
+        throw new IOException("External policy contains no modules: " + entryName);
+      }
+      if (appPolicy.modules().size() > 1) {
+        throw new IOException(
+            "External policy contains multiple modules ("
+                + appPolicy.modules().size()
+                + "). Each file should contain policy for one module: "
+                + entryName);
+      }
+
+      return appPolicy.modules().get(0);
+    }
+  }
+
+  /**
    * Discovers policies from directory entries on the classpath.
    *
    * <p>This supports development/testing scenarios where Gradle outputs compiled policies to class
-   * directories rather than JARs.
+   * directories rather than JARs. Both embedded policies ({@code META-INF/jguard/policy.bin}) and
+   * external policies ({@code META-INF/jguard/external/*.bin}) are discovered.
    *
    * @param config the agent configuration
    * @param dirPaths the directories to scan
@@ -206,42 +313,81 @@ public final class PolicyDiscovery {
       throws PolicyDiscoveryException {
 
     for (Path dirPath : dirPaths) {
-      Path policyFile = dirPath.resolve(JarSignatureVerifier.POLICY_LOCATION);
-      if (!Files.exists(policyFile)) {
-        continue;
-      }
-
       // Directory-based policies require allowUnsignedPolicies since directories can't be signed
       if (!config.allowUnsignedPolicies()) {
-        LOG.warn(
-            "Skipping directory-based policy at {}. "
-                + "Set -Djguard.allowUnsignedPolicies=true for development.",
-            policyFile);
+        Path policyFile = dirPath.resolve(JarSignatureVerifier.POLICY_LOCATION);
+        Path externalDir = dirPath.resolve(JarSignatureVerifier.EXTERNAL_POLICIES_DIR);
+        if (Files.exists(policyFile) || Files.isDirectory(externalDir)) {
+          LOG.warn(
+              "Skipping directory-based policies at {}. "
+                  + "Set -Djguard.allowUnsignedPolicies=true for development.",
+              dirPath);
+        }
         continue;
       }
 
-      try {
-        ModulePolicy policy = readPolicyFromDirectory(policyFile);
+      // Discover embedded policy
+      Path policyFile = dirPath.resolve(JarSignatureVerifier.POLICY_LOCATION);
+      if (Files.exists(policyFile)) {
+        try {
+          ModulePolicy policy = readPolicyFromDirectory(policyFile);
 
-        // Check for duplicates
-        String existingSource = moduleToSource.get(policy.moduleName());
-        if (existingSource != null) {
-          throw new PolicyDiscoveryException(
-              String.format(
-                  "Duplicate policy for module '%s' found in:%n  - %s%n  - %s",
-                  policy.moduleName(), existingSource, dirPath));
+          // Check for duplicates
+          String existingSource = moduleToSource.get(policy.moduleName());
+          if (existingSource != null) {
+            throw new PolicyDiscoveryException(
+                String.format(
+                    "Duplicate policy for module '%s' found in:%n  - %s%n  - %s",
+                    policy.moduleName(), existingSource, dirPath));
+          }
+
+          moduleToSource.put(policy.moduleName(), dirPath.toString());
+          policies.add(policy);
+          LOG.info(
+              "Discovered policy for module '{}' from directory {} ({} entitlements)",
+              policy.moduleName(),
+              dirPath,
+              policy.entitlements().size());
+
+        } catch (IOException e) {
+          LOG.warn("Failed to read policy from directory {}: {}", dirPath, e.getMessage());
         }
+      }
 
-        moduleToSource.put(policy.moduleName(), dirPath.toString());
-        policies.add(policy);
-        LOG.info(
-            "Discovered policy for module '{}' from directory {} ({} entitlements)",
-            policy.moduleName(),
-            dirPath,
-            policy.entitlements().size());
+      // Discover external policies
+      Path externalDir = dirPath.resolve(JarSignatureVerifier.EXTERNAL_POLICIES_DIR);
+      if (Files.isDirectory(externalDir)) {
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(externalDir, "*.bin")) {
+          for (Path externalPolicyFile : stream) {
+            try {
+              ModulePolicy policy = readPolicyFromDirectory(externalPolicyFile);
 
-      } catch (IOException e) {
-        LOG.warn("Failed to read policy from directory {}: {}", dirPath, e.getMessage());
+              // Check for duplicates
+              String existingSource = moduleToSource.get(policy.moduleName());
+              if (existingSource != null) {
+                throw new PolicyDiscoveryException(
+                    String.format(
+                        "Duplicate policy for module '%s' found in:%n  - %s%n  - %s (external)",
+                        policy.moduleName(), existingSource, externalPolicyFile));
+              }
+
+              moduleToSource.put(policy.moduleName(), externalPolicyFile.toString());
+              policies.add(policy);
+              LOG.info(
+                  "Discovered external policy for module '{}' from directory {} ({} entitlements)",
+                  policy.moduleName(),
+                  externalPolicyFile.getFileName(),
+                  policy.entitlements().size());
+
+            } catch (IOException e) {
+              LOG.warn(
+                  "Failed to read external policy from {}: {}", externalPolicyFile, e.getMessage());
+            }
+          }
+        } catch (IOException e) {
+          LOG.warn(
+              "Failed to scan external policies directory {}: {}", externalDir, e.getMessage());
+        }
       }
     }
   }

--- a/agent/src/test/java/io/jguard/agent/PolicyDiscoveryTest.java
+++ b/agent/src/test/java/io/jguard/agent/PolicyDiscoveryTest.java
@@ -309,4 +309,230 @@ class PolicyDiscoveryTest {
   void setUp() {
     // Ensure we start with a clean slate
   }
+
+  @Nested
+  @DisplayName("External Policy Discovery")
+  class ExternalPolicyDiscoveryTest {
+
+    @Test
+    @DisplayName("discovers external policies from JAR at META-INF/jguard/external/")
+    void discoversExternalPoliciesFromJar() throws Exception {
+      // Create a JAR with external policies (no embedded policy)
+      Path jarPath = createJarWithExternalPolicies(List.of("io.netty.common", "io.netty.handler"));
+
+      String originalClasspath = System.getProperty("java.class.path");
+      try {
+        System.setProperty("java.class.path", jarPath.toString());
+
+        AgentConfig config =
+            new AgentConfig.Builder()
+                .discoveryEnabled(true)
+                .allowUnsignedPolicies(true)
+                .mode(EnforcementMode.STRICT)
+                .build();
+
+        ApplicationPolicy policy = PolicyDiscovery.discoverEmbedded(config);
+
+        assertThat(policy.modules()).hasSize(2);
+        assertThat(policy.hasModule("io.netty.common")).isTrue();
+        assertThat(policy.hasModule("io.netty.handler")).isTrue();
+      } finally {
+        System.setProperty("java.class.path", originalClasspath);
+      }
+    }
+
+    @Test
+    @DisplayName("discovers both embedded and external policies from same JAR")
+    void discoversBothEmbeddedAndExternalFromSameJar() throws Exception {
+      // Create a JAR with both embedded and external policies
+      Path jarPath =
+          createJarWithEmbeddedAndExternalPolicies("com.example.app", List.of("io.netty.common"));
+
+      String originalClasspath = System.getProperty("java.class.path");
+      try {
+        System.setProperty("java.class.path", jarPath.toString());
+
+        AgentConfig config =
+            new AgentConfig.Builder()
+                .discoveryEnabled(true)
+                .allowUnsignedPolicies(true)
+                .mode(EnforcementMode.STRICT)
+                .build();
+
+        ApplicationPolicy policy = PolicyDiscovery.discoverEmbedded(config);
+
+        assertThat(policy.modules()).hasSize(2);
+        assertThat(policy.hasModule("com.example.app")).isTrue();
+        assertThat(policy.hasModule("io.netty.common")).isTrue();
+      } finally {
+        System.setProperty("java.class.path", originalClasspath);
+      }
+    }
+
+    @Test
+    @DisplayName("discovers external policies from directories")
+    void discoversExternalPoliciesFromDirectories() throws Exception {
+      // Create a directory structure with external policies
+      Path classDir = tempDir.resolve("classes");
+      Path externalDir = classDir.resolve(JarSignatureVerifier.EXTERNAL_POLICIES_DIR);
+      Files.createDirectories(externalDir);
+
+      // Create external policy files
+      createPolicyFileAt(externalDir.resolve("io.netty.common.bin"), "io.netty.common");
+      createPolicyFileAt(externalDir.resolve("io.netty.handler.bin"), "io.netty.handler");
+
+      String originalClasspath = System.getProperty("java.class.path");
+      try {
+        System.setProperty("java.class.path", classDir.toString());
+
+        AgentConfig config =
+            new AgentConfig.Builder()
+                .discoveryEnabled(true)
+                .allowUnsignedPolicies(true)
+                .mode(EnforcementMode.STRICT)
+                .build();
+
+        ApplicationPolicy policy = PolicyDiscovery.discoverEmbedded(config);
+
+        assertThat(policy.modules()).hasSize(2);
+        assertThat(policy.hasModule("io.netty.common")).isTrue();
+        assertThat(policy.hasModule("io.netty.handler")).isTrue();
+      } finally {
+        System.setProperty("java.class.path", originalClasspath);
+      }
+    }
+
+    @Test
+    @DisplayName("fails on duplicate external policies from multiple JARs")
+    void failsOnDuplicateExternalPolicies() throws Exception {
+      Path jarA = createJarWithExternalPolicies(List.of("io.netty.common"));
+      Path jarB = createJarWithExternalPolicies(List.of("io.netty.common")); // Same module
+
+      String originalClasspath = System.getProperty("java.class.path");
+      try {
+        System.setProperty("java.class.path", jarA + File.pathSeparator + jarB);
+
+        AgentConfig config =
+            new AgentConfig.Builder()
+                .discoveryEnabled(true)
+                .allowUnsignedPolicies(true)
+                .mode(EnforcementMode.STRICT)
+                .build();
+
+        assertThatThrownBy(() -> PolicyDiscovery.discoverEmbedded(config))
+            .isInstanceOf(PolicyDiscovery.PolicyDiscoveryException.class)
+            .hasMessageContaining("Duplicate policy")
+            .hasMessageContaining("io.netty.common");
+      } finally {
+        System.setProperty("java.class.path", originalClasspath);
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("JarSignatureVerifier External Policy Methods")
+  class JarSignatureVerifierExternalTest {
+
+    @Test
+    @DisplayName("findExternalPolicyEntries returns entries for external policies")
+    void findExternalPolicyEntriesReturnsEntries() throws Exception {
+      Path jarPath = createJarWithExternalPolicies(List.of("io.netty.common", "io.netty.handler"));
+
+      try (java.util.jar.JarFile jarFile = new java.util.jar.JarFile(jarPath.toFile())) {
+        List<String> entries = JarSignatureVerifier.findExternalPolicyEntries(jarFile);
+        assertThat(entries).hasSize(2);
+        assertThat(entries).anyMatch(e -> e.contains("io.netty.common"));
+        assertThat(entries).anyMatch(e -> e.contains("io.netty.handler"));
+      }
+    }
+
+    @Test
+    @DisplayName("findExternalPolicyEntries returns empty for JAR without external policies")
+    void findExternalPolicyEntriesReturnsEmpty() throws Exception {
+      Path jarPath = createJarWithPolicy("com.example.app");
+
+      try (java.util.jar.JarFile jarFile = new java.util.jar.JarFile(jarPath.toFile())) {
+        List<String> entries = JarSignatureVerifier.findExternalPolicyEntries(jarFile);
+        assertThat(entries).isEmpty();
+      }
+    }
+  }
+
+  // ===== Additional helper methods for external policies =====
+
+  private Path createJarWithExternalPolicies(List<String> moduleNames) throws Exception {
+    Path jarPath = tempDir.resolve("external-policies-" + System.nanoTime() + ".jar");
+
+    try (JarOutputStream jos = new JarOutputStream(new FileOutputStream(jarPath.toFile()))) {
+      for (String moduleName : moduleNames) {
+        ModulePolicy modulePolicy =
+            new ModulePolicy(
+                moduleName,
+                List.of(
+                    new Entitlement(
+                        SubjectPattern.module(), CapabilityGrant.of("threads.create"))));
+        ApplicationPolicy appPolicy = ApplicationPolicy.single(modulePolicy);
+        byte[] policyBytes = BinaryPolicyWriter.toBytes(appPolicy);
+
+        // Add external policy entry
+        String entryName = JarSignatureVerifier.EXTERNAL_POLICIES_DIR + "/" + moduleName + ".bin";
+        jos.putNextEntry(new JarEntry(entryName));
+        jos.write(policyBytes);
+        jos.closeEntry();
+      }
+    }
+
+    return jarPath;
+  }
+
+  private Path createJarWithEmbeddedAndExternalPolicies(
+      String embeddedModule, List<String> externalModules) throws Exception {
+    Path jarPath = tempDir.resolve("mixed-policies-" + System.nanoTime() + ".jar");
+
+    try (JarOutputStream jos = new JarOutputStream(new FileOutputStream(jarPath.toFile()))) {
+      // Add embedded policy
+      ModulePolicy embeddedPolicy =
+          new ModulePolicy(
+              embeddedModule,
+              List.of(
+                  new Entitlement(SubjectPattern.module(), CapabilityGrant.of("threads.create"))));
+      ApplicationPolicy embeddedAppPolicy = ApplicationPolicy.single(embeddedPolicy);
+      byte[] embeddedBytes = BinaryPolicyWriter.toBytes(embeddedAppPolicy);
+
+      jos.putNextEntry(new JarEntry(JarSignatureVerifier.POLICY_LOCATION));
+      jos.write(embeddedBytes);
+      jos.closeEntry();
+
+      // Add external policies
+      for (String moduleName : externalModules) {
+        ModulePolicy externalPolicy =
+            new ModulePolicy(
+                moduleName,
+                List.of(
+                    new Entitlement(
+                        SubjectPattern.module(), CapabilityGrant.of("network.outbound"))));
+        ApplicationPolicy externalAppPolicy = ApplicationPolicy.single(externalPolicy);
+        byte[] externalBytes = BinaryPolicyWriter.toBytes(externalAppPolicy);
+
+        String entryName = JarSignatureVerifier.EXTERNAL_POLICIES_DIR + "/" + moduleName + ".bin";
+        jos.putNextEntry(new JarEntry(entryName));
+        jos.write(externalBytes);
+        jos.closeEntry();
+      }
+    }
+
+    return jarPath;
+  }
+
+  private void createPolicyFileAt(Path path, String moduleName) throws Exception {
+    ModulePolicy modulePolicy =
+        new ModulePolicy(
+            moduleName,
+            List.of(
+                new Entitlement(SubjectPattern.module(), CapabilityGrant.of("threads.create"))));
+    ApplicationPolicy appPolicy = ApplicationPolicy.single(modulePolicy);
+    byte[] policyBytes = BinaryPolicyWriter.toBytes(appPolicy);
+
+    Files.write(path, policyBytes);
+  }
 }

--- a/gradle-plugin/src/main/java/io/jguard/gradle/policy/JGuardPolicyExtension.java
+++ b/gradle-plugin/src/main/java/io/jguard/gradle/policy/JGuardPolicyExtension.java
@@ -137,18 +137,22 @@ public abstract class JGuardPolicyExtension {
   /**
    * The source directory containing external policy {@code .jguard} files.
    *
-   * <p>All {@code *.jguard} files in this directory will be compiled to binary format. The output
-   * filename will be derived from the source filename (e.g., {@code _global.jguard} becomes {@code
-   * _global.bin}, {@code com.example.lib.jguard} becomes {@code com.example.lib.bin}).
+   * <p>All {@code *.jguard} files in this directory will be compiled to binary format and packaged
+   * into the JAR at {@code META-INF/jguard/external/}. These policies provide capabilities for
+   * third-party libraries that don't ship with their own jGuard policies.
    *
-   * <p>Default: not set (external policy compilation disabled)
+   * <p>The output filename will be derived from the source filename (e.g., {@code io.netty.jguard}
+   * becomes {@code io.netty.bin}).
+   *
+   * <p>Default: {@code src/main/jguard} (mirrors {@code src/test/jguard} for test policies)
    *
    * <p>Example usage:
    *
    * <pre>
-   * jguardPolicy {
-   *     externalPoliciesSourceDir = file("policies-src")
-   *     externalPoliciesOutputDir = file("policies")
+   * // File: src/main/jguard/io.netty.common.jguard
+   * security module io.netty.common {
+   *     entitle io.netty.common.. to threads.create;
+   *     entitle io.netty.common.. to network.outbound;
    * }
    * </pre>
    */
@@ -157,10 +161,10 @@ public abstract class JGuardPolicyExtension {
   /**
    * The output directory for compiled external policy {@code .bin} files.
    *
-   * <p>This is the directory that should be passed to the jGuard agent via {@code
-   * -Djguard.policy.override=/path/to/policies}.
+   * <p>This directory is automatically included in the JAR at {@code META-INF/jguard/external/}.
+   * The agent discovers these policies alongside embedded policies.
    *
-   * <p>Default: {@code build/external-policies/}
+   * <p>Default: {@code build/jguard-policy/META-INF/jguard/external/}
    */
   public abstract DirectoryProperty getExternalPoliciesOutputDir();
 

--- a/gradle-plugin/src/main/java/io/jguard/gradle/policy/JGuardPolicyPlugin.java
+++ b/gradle-plugin/src/main/java/io/jguard/gradle/policy/JGuardPolicyPlugin.java
@@ -215,6 +215,60 @@ public class JGuardPolicyPlugin implements Plugin<Project> {
                   .getTasks()
                   .named(JavaPlugin.JAR_TASK_NAME, Jar.class, jar -> jar.dependsOn(compileTask));
 
+              // 5. JAR task depends on compileExternalPolicies when external policies exist
+              //    External policies are compiled to build/jguard-policy/META-INF/jguard/external/
+              //    and should be included in the JAR alongside embedded policies.
+              TaskProvider<CompileExternalPoliciesTask> externalPoliciesTaskProvider =
+                  project
+                      .getTasks()
+                      .named(EXTERNAL_POLICIES_TASK_NAME, CompileExternalPoliciesTask.class);
+              project
+                  .getTasks()
+                  .named(
+                      JavaPlugin.JAR_TASK_NAME,
+                      Jar.class,
+                      jar ->
+                          jar.dependsOn(
+                              project.provider(
+                                  () -> {
+                                    if (extension.getExternalPoliciesSourceDir().isPresent()) {
+                                      File sourceDir =
+                                          extension
+                                              .getExternalPoliciesSourceDir()
+                                              .get()
+                                              .getAsFile();
+                                      if (sourceDir.exists() && sourceDir.isDirectory()) {
+                                        return externalPoliciesTaskProvider;
+                                      }
+                                    }
+                                    return project.files();
+                                  })));
+
+              // 6. compileTestJava depends on compileExternalPolicies when external policies exist
+              //    External policies output to build/jguard-policy which is part of main source set
+              //    output, and test compilation uses main output on its classpath.
+              project
+                  .getTasks()
+                  .named(
+                      JavaPlugin.COMPILE_TEST_JAVA_TASK_NAME,
+                      JavaCompile.class,
+                      task ->
+                          task.dependsOn(
+                              project.provider(
+                                  () -> {
+                                    if (extension.getExternalPoliciesSourceDir().isPresent()) {
+                                      File sourceDir =
+                                          extension
+                                              .getExternalPoliciesSourceDir()
+                                              .get()
+                                              .getAsFile();
+                                      if (sourceDir.exists() && sourceDir.isDirectory()) {
+                                        return externalPoliciesTaskProvider;
+                                      }
+                                    }
+                                    return project.files();
+                                  })));
+
               // Only configure module path inference for modular projects (those with
               // module-info.java).
               // For non-modular projects, jGuard still works using the "unnamed module" mechanism.
@@ -302,11 +356,7 @@ public class JGuardPolicyPlugin implements Plugin<Project> {
                         task.dependsOn(compileTask);
 
                         // Also depend on external policies if configured
-                        TaskProvider<CompileExternalPoliciesTask> externalPoliciesTaskProvider =
-                            project
-                                .getTasks()
-                                .named(
-                                    EXTERNAL_POLICIES_TASK_NAME, CompileExternalPoliciesTask.class);
+                        // (reuse externalPoliciesTaskProvider from above)
                         task.dependsOn(
                             project.provider(
                                 () -> {
@@ -694,10 +744,17 @@ public class JGuardPolicyPlugin implements Plugin<Project> {
     extension.getAllowUnsignedPolicies().convention(false);
 
     // External policies defaults
-    // Note: externalPoliciesSourceDir has no default - must be explicitly set to enable
+    // Default source directory is src/main/jguard for policies shipped with the JAR
+    // This mirrors src/test/jguard for test policies
+    extension
+        .getExternalPoliciesSourceDir()
+        .convention(project.getLayout().getProjectDirectory().dir("src/main/jguard"));
+    // Output to build/jguard-policy/META-INF/jguard/external/ so policies are packaged in JAR
+    // This is discovered by the agent at META-INF/jguard/external/*.bin
     extension
         .getExternalPoliciesOutputDir()
-        .convention(project.getLayout().getBuildDirectory().dir("external-policies"));
+        .convention(
+            project.getLayout().getBuildDirectory().dir("jguard-policy/META-INF/jguard/external"));
     extension.getExternalPoliciesIncludeJson().convention(false);
 
     // Test policies defaults


### PR DESCRIPTION
# Description

Modules can now ship policies for their runtime dependencies (e.g., Netty, Reactor) by placing them in src/main/jguard/. These policies are compiled to META-INF/jguard/external/*.bin in the JAR and automatically discovered by the agent alongside embedded policies.

This enables applications to define capabilities for third-party libraries without requiring manual -Djguard.policy.override configuration at runtime. Same signing requirements apply as embedded policies.

Changes:
- Agent: Add external policy discovery from META-INF/jguard/external/*.bin in both JARs and directories (for development)
- JarSignatureVerifier: Add findExternalPolicyEntries(), isEntrySigned(), and make hasSignatures() public
- Gradle plugin: Default externalPoliciesSourceDir to src/main/jguard/ (mirrors src/test/jguard/ for test policies)
- Gradle plugin: Output external policies to build/jguard-policy/META-INF/ jguard/external/ so they're packaged in JARs
- Gradle plugin: Add compileTestJava dependency on compileExternalPolicies to fix Gradle task dependency validation error
- Add comprehensive tests for external policy discovery

