### PR TITLE
(fix) external policy JAR packaging and add discovery debug logging

### DIFF
--- a/agent/src/main/java/io/jguard/agent/PolicyDiscovery.java
+++ b/agent/src/main/java/io/jguard/agent/PolicyDiscovery.java
@@ -127,6 +127,16 @@ public final class PolicyDiscovery {
           "Policy discovery complete: {} module(s), {} total entitlements",
           policies.size(),
           policies.stream().mapToInt(p -> p.entitlements().size()).sum());
+
+      // Log all discovered modules at debug level
+      LOG.debug("Discovered modules:");
+      for (ModulePolicy mp : policies) {
+        LOG.debug(
+            "  - {} ({} entitlements, trusted={})",
+            mp.moduleName(),
+            mp.entitlements().size(),
+            mp.trusted());
+      }
     }
 
     return ApplicationPolicy.create(policies);
@@ -155,6 +165,9 @@ public final class PolicyDiscovery {
       Map<String, String> moduleToSource)
       throws PolicyDiscoveryException {
 
+    LOG.debug("Starting JAR scan for embedded and external policies");
+    LOG.debug("allowUnsignedPolicies={}", config.allowUnsignedPolicies());
+
     for (Path jarPath : jarPaths) {
       try (JarFile jarFile = new JarFile(jarPath.toFile(), true)) { // true = verify signatures
         boolean hasEmbedded = JarSignatureVerifier.hasEmbeddedPolicy(jarFile);
@@ -162,6 +175,15 @@ public final class PolicyDiscovery {
 
         if (!hasEmbedded && externalEntries.isEmpty()) {
           continue;
+        }
+
+        LOG.debug(
+            "JAR {} has policies: embedded={}, external={}",
+            jarPath.getFileName(),
+            hasEmbedded,
+            externalEntries.size());
+        if (!externalEntries.isEmpty()) {
+          LOG.debug("External policy entries in {}: {}", jarPath.getFileName(), externalEntries);
         }
 
         // Check signature (unless unsigned allowed)
@@ -185,9 +207,17 @@ public final class PolicyDiscovery {
           }
           isSignedJar = true;
         } else {
-          LOG.debug("Allowing unsigned policies from {} (development mode)", jarPath);
+          LOG.debug(
+              "Allowing unsigned policies from {} (development mode, allowUnsignedPolicies=true)",
+              jarPath.getFileName());
           isSignedJar = false;
         }
+
+        LOG.debug(
+            "Processing {} policies from {}: isSignedJar={}",
+            hasEmbedded ? "embedded" : "" + (!externalEntries.isEmpty() ? " + external" : ""),
+            jarPath.getFileName(),
+            isSignedJar);
 
         // Discover embedded policy
         if (hasEmbedded) {
@@ -221,7 +251,13 @@ public final class PolicyDiscovery {
         }
 
         // Discover external policies
+        LOG.debug(
+            "Processing {} external policy entries from {}",
+            externalEntries.size(),
+            jarPath.getFileName());
         for (String entryName : externalEntries) {
+          LOG.debug("Reading external policy entry: {}", entryName);
+
           // Verify signature on each external policy entry
           if (isSignedJar && !config.allowUnsignedPolicies()) {
             if (!JarSignatureVerifier.isEntrySigned(jarFile, entryName)) {
@@ -231,6 +267,11 @@ public final class PolicyDiscovery {
           }
 
           ModulePolicy policy = readExternalPolicy(jarFile, entryName);
+          LOG.debug(
+              "Read external policy: module='{}', entitlements={}, trusted={}",
+              policy.moduleName(),
+              policy.entitlements().size(),
+              policy.trusted());
 
           // Check for duplicates
           String existingSource = moduleToSource.get(policy.moduleName());
@@ -312,7 +353,14 @@ public final class PolicyDiscovery {
       Map<String, String> moduleToSource)
       throws PolicyDiscoveryException {
 
+    LOG.debug("Starting directory scan for embedded and external policies");
+    LOG.debug(
+        "Scanning {} directories, allowUnsignedPolicies={}",
+        dirPaths.size(),
+        config.allowUnsignedPolicies());
+
     for (Path dirPath : dirPaths) {
+      LOG.debug("Checking directory: {}", dirPath);
       // Directory-based policies require allowUnsignedPolicies since directories can't be signed
       if (!config.allowUnsignedPolicies()) {
         Path policyFile = dirPath.resolve(JarSignatureVerifier.POLICY_LOCATION);
@@ -356,9 +404,14 @@ public final class PolicyDiscovery {
 
       // Discover external policies
       Path externalDir = dirPath.resolve(JarSignatureVerifier.EXTERNAL_POLICIES_DIR);
+      LOG.debug(
+          "Checking for external policies at: {} (exists={})",
+          externalDir,
+          Files.isDirectory(externalDir));
       if (Files.isDirectory(externalDir)) {
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(externalDir, "*.bin")) {
           for (Path externalPolicyFile : stream) {
+            LOG.debug("Found external policy file: {}", externalPolicyFile);
             try {
               ModulePolicy policy = readPolicyFromDirectory(externalPolicyFile);
 

--- a/gradle-plugin/src/main/java/io/jguard/gradle/policy/JGuardPolicyPlugin.java
+++ b/gradle-plugin/src/main/java/io/jguard/gradle/policy/JGuardPolicyPlugin.java
@@ -194,16 +194,29 @@ public class JGuardPolicyPlugin implements Plugin<Project> {
 
               // 2. Register policy output as part of main source set output.
               //    This tells Gradle that any consumer of this source set (via project
-              //    dependencies) must wait for compileJGuardPolicy. Without this, cross-project
-              //    dependencies would not know about the policy compilation task.
+              //    dependencies) must wait for policy compilation tasks. Without this,
+              // cross-project
+              //    dependencies would not know about the policy compilation tasks.
               //    We register build/jguard-policy (the parent), not the full path, so that
               //    META-INF/jguard/policy.bin structure is preserved in the JAR.
+              //    Both embedded and external policies are built by their respective tasks.
               SourceSetContainer sourceSets =
                   project.getExtensions().getByType(SourceSetContainer.class);
               SourceSet mainSourceSet = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME);
               Provider<Directory> policyRootDir =
                   project.getLayout().getBuildDirectory().dir("jguard-policy");
-              mainSourceSet.getOutput().dir(Map.of("builtBy", compileTask), policyRootDir);
+
+              // Get the external policies task provider for use in builtBy
+              TaskProvider<CompileExternalPoliciesTask> externalPoliciesTask =
+                  project
+                      .getTasks()
+                      .named(EXTERNAL_POLICIES_TASK_NAME, CompileExternalPoliciesTask.class);
+
+              // Register with both embedded and external policy tasks as builders
+              mainSourceSet
+                  .getOutput()
+                  .dir(
+                      Map.of("builtBy", List.of(compileTask, externalPoliciesTask)), policyRootDir);
 
               // 3. The 'classes' task must depend on compileJGuardPolicy
               project
@@ -218,31 +231,44 @@ public class JGuardPolicyPlugin implements Plugin<Project> {
               // 5. JAR task depends on compileExternalPolicies when external policies exist
               //    External policies are compiled to build/jguard-policy/META-INF/jguard/external/
               //    and should be included in the JAR alongside embedded policies.
-              TaskProvider<CompileExternalPoliciesTask> externalPoliciesTaskProvider =
-                  project
-                      .getTasks()
-                      .named(EXTERNAL_POLICIES_TASK_NAME, CompileExternalPoliciesTask.class);
+              //    We explicitly add the external policies to the JAR in case the
+              // sourceSets.main.output
+              //    registration isn't being picked up by custom JAR configurations.
               project
                   .getTasks()
                   .named(
                       JavaPlugin.JAR_TASK_NAME,
                       Jar.class,
-                      jar ->
-                          jar.dependsOn(
-                              project.provider(
-                                  () -> {
-                                    if (extension.getExternalPoliciesSourceDir().isPresent()) {
-                                      File sourceDir =
-                                          extension
-                                              .getExternalPoliciesSourceDir()
-                                              .get()
-                                              .getAsFile();
-                                      if (sourceDir.exists() && sourceDir.isDirectory()) {
-                                        return externalPoliciesTaskProvider;
-                                      }
+                      jar -> {
+                        jar.dependsOn(
+                            project.provider(
+                                () -> {
+                                  if (extension.getExternalPoliciesSourceDir().isPresent()) {
+                                    File sourceDir =
+                                        extension.getExternalPoliciesSourceDir().get().getAsFile();
+                                    if (sourceDir.exists() && sourceDir.isDirectory()) {
+                                      return externalPoliciesTask;
                                     }
-                                    return project.files();
-                                  })));
+                                  }
+                                  return project.files();
+                                }));
+
+                        // Explicitly include external policies in JAR
+                        // This ensures they're included even if custom JAR packaging is used
+                        // The policyRootDir (build/jguard-policy) contains META-INF/jguard/...
+                        jar.from(
+                            project.provider(
+                                () -> {
+                                  if (extension.getExternalPoliciesSourceDir().isPresent()) {
+                                    File sourceDir =
+                                        extension.getExternalPoliciesSourceDir().get().getAsFile();
+                                    if (sourceDir.exists() && sourceDir.isDirectory()) {
+                                      return policyRootDir.get().getAsFile();
+                                    }
+                                  }
+                                  return project.files();
+                                }));
+                      });
 
               // 6. compileTestJava depends on compileExternalPolicies when external policies exist
               //    External policies output to build/jguard-policy which is part of main source set
@@ -263,7 +289,7 @@ public class JGuardPolicyPlugin implements Plugin<Project> {
                                               .get()
                                               .getAsFile();
                                       if (sourceDir.exists() && sourceDir.isDirectory()) {
-                                        return externalPoliciesTaskProvider;
+                                        return externalPoliciesTask;
                                       }
                                     }
                                     return project.files();
@@ -356,7 +382,7 @@ public class JGuardPolicyPlugin implements Plugin<Project> {
                         task.dependsOn(compileTask);
 
                         // Also depend on external policies if configured
-                        // (reuse externalPoliciesTaskProvider from above)
+                        // (reuse externalPoliciesTask from above)
                         task.dependsOn(
                             project.provider(
                                 () -> {
@@ -364,7 +390,7 @@ public class JGuardPolicyPlugin implements Plugin<Project> {
                                     File sourceDir =
                                         extension.getExternalPoliciesSourceDir().get().getAsFile();
                                     if (sourceDir.exists() && sourceDir.isDirectory()) {
-                                      return externalPoliciesTaskProvider;
+                                      return externalPoliciesTask;
                                     }
                                   }
                                   return project.files(); // Empty dependency if not configured


### PR DESCRIPTION
# Description
Gradle plugin:
- Register both embedded and external policy tasks in sourceSets builtBy
- Add explicit jar.from() for external policies to handle custom JAR configs
- Ensures external policies at META-INF/jguard/external/*.bin are packaged

Agent:
- Add DEBUG-level logging for policy discovery from JARs and directories
- Logs which JARs contain policies, external entries found, and final module list
- Helps diagnose policy discovery issues (enabled via -Djguard.log.level=debug)
