### PR TITLE
(enhance) Improve audit mode developer experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Test-specific policy overrides**: New `src/test/jguard/` directory support for test-only policies. Test policies extend embedded policies with additional permissions needed during testing (e.g., temp file access, thread creation). Policies are compiled by the `compileTestPolicies` task and automatically passed to the agent during test execution.
 - **Multi-directory policy overrides**: The agent now supports comma-separated paths in `-Djguard.policy.override`, allowing layered policy overrides. Later directories take precedence.
 - **Embedded external policies**: Modules can now ship policies for third-party dependencies by placing them in `src/main/jguard/`. These policies are compiled to `META-INF/jguard/external/*.bin` in the JAR and automatically discovered by the agent alongside embedded policies. This enables applications to define capabilities for runtime dependencies (e.g., Netty, Reactor) without requiring manual `-Djguard.policy.override` configuration. Same signing requirements apply as embedded policies.
+- **Audit mode summary**: In audit mode, the agent now accumulates all unique denials and prints a summary at JVM shutdown. This shows all missing entitlements in one run instead of discovering them one-by-one.
+- **Suggested policy output**: At shutdown in audit mode, the agent prints copy-paste-ready `.jguard` policy syntax based on observed denials. This dramatically speeds up initial policy authoring for new projects.
+- **Policy discovery debug logging**: Added DEBUG-level logging for policy discovery from JARs and directories. Enable with `-Djguard.log.level=debug` to diagnose policy loading issues.
 
 ### Fixed
 
@@ -19,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Embedded policies not discovered during tests**: Fixed policy discovery for tests by outputting compiled policies to `build/jguard-policy/META-INF/jguard/` and registering this directory with `sourceSets.main.output.dir()`. This ensures policies are on the test classpath and properly packaged into JARs.
 - **Gradle cross-project dependency ordering**: Fixed `compileJGuardPolicy` task lifecycle wiring. Policies now output to a dedicated `build/jguard-policy/` directory (avoiding conflicts with `compileJava`'s output), registered via `sourceSets.main.output.dir(builtBy: compileJGuardPolicy)`. This ensures cross-project dependencies (via `project(':other')`) automatically wait for policy compilation.
 - **Directory-based policy discovery**: Fixed agent to discover embedded policies from directories on the classpath, not just JAR files. This enables policy discovery during development/testing when using Gradle class directories (`build/classes/java/main`).
+- **Gradle clean task**: The `clean` task now removes `build/jguard-policy/` and `build/test-policies/` directories, preventing stale compiled policy files from causing conflicts.
 
 ## [0.3.1] - 2026-01-30
 

--- a/agent-bootstrap/src/main/java/io/jguard/bootstrap/BootstrapEnforcer.java
+++ b/agent-bootstrap/src/main/java/io/jguard/bootstrap/BootstrapEnforcer.java
@@ -11,6 +11,11 @@ import java.io.File;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 /**
  * Bootstrap enforcement bridge for jGuard.
@@ -86,6 +91,24 @@ public final class BootstrapEnforcer {
   /** Flag to prevent re-entrant calls during enforcement. */
   private static final ThreadLocal<Boolean> IN_ENFORCEMENT = new ThreadLocal<>();
 
+  // ========== AUDIT MODE DENIAL ACCUMULATION ==========
+
+  /**
+   * Represents a unique denial for audit mode accumulation.
+   *
+   * <p>Denials are considered unique based on (moduleName, packageName, operation, args).
+   */
+  record DenialRecord(String moduleName, String packageName, Operation operation, String args) {}
+
+  /** Thread-safe set of accumulated denials in audit mode. */
+  private static final Set<DenialRecord> auditDenials = ConcurrentHashMap.newKeySet();
+
+  /** Flag to track if shutdown hook is registered. */
+  private static volatile boolean shutdownHookRegistered = false;
+
+  /** Lock object for shutdown hook registration. */
+  private static final Object SHUTDOWN_HOOK_LOCK = new Object();
+
   private BootstrapEnforcer() {}
 
   // ========== CONFIGURATION ==========
@@ -105,11 +128,72 @@ public final class BootstrapEnforcer {
   /**
    * Sets the enforcement mode.
    *
+   * <p>When AUDIT mode is set, registers a JVM shutdown hook to log accumulated denials.
+   *
    * @param enforcementMode the mode to use
    */
   public static void setMode(EnforcementMode enforcementMode) {
     mode = enforcementMode;
     LOG.debug("Enforcement mode set to: {}", enforcementMode);
+
+    // Register shutdown hook for audit mode summary
+    if (enforcementMode == EnforcementMode.AUDIT) {
+      registerAuditShutdownHook();
+    }
+  }
+
+  /**
+   * Registers the audit mode shutdown hook if not already registered.
+   *
+   * <p>The hook logs a summary of all accumulated denials at JVM shutdown.
+   */
+  private static void registerAuditShutdownHook() {
+    if (shutdownHookRegistered) {
+      return;
+    }
+
+    synchronized (SHUTDOWN_HOOK_LOCK) {
+      if (shutdownHookRegistered) {
+        return;
+      }
+
+      Runtime.getRuntime()
+          .addShutdownHook(
+              new Thread(
+                  () -> {
+                    if (auditDenials.isEmpty()) {
+                      return;
+                    }
+
+                    // Group denials by module
+                    Map<String, List<DenialRecord>> byModule =
+                        auditDenials.stream()
+                            .collect(Collectors.groupingBy(DenialRecord::moduleName));
+
+                    // Log summary header
+                    LOG.warn(
+                        "AUDIT SUMMARY: {} unique denial(s) across {} module(s)",
+                        auditDenials.size(),
+                        byModule.size());
+
+                    // Log denials grouped by module
+                    byModule.forEach(
+                        (moduleName, denials) -> {
+                          LOG.warn("  Module: {}", moduleName);
+                          for (DenialRecord denial : denials) {
+                            LOG.warn(
+                                "    DENIED {}: package={}, args={}",
+                                denial.operation(),
+                                denial.packageName(),
+                                denial.args());
+                          }
+                        });
+                  },
+                  "jguard-audit-summary"));
+
+      shutdownHookRegistered = true;
+      LOG.debug("Audit mode shutdown hook registered");
+    }
   }
 
   /**
@@ -494,7 +578,14 @@ public final class BootstrapEnforcer {
 
       if (denial != null) {
         // Access denied
-        if (logDenied) {
+        if (mode == EnforcementMode.AUDIT) {
+          // Audit mode: accumulate denials for summary at shutdown
+          String args = formatArgs(op, arg0, arg1);
+          DenialRecord record =
+              new DenialRecord(caller.moduleName(), caller.packageName(), op, args);
+          auditDenials.add(record);
+        } else if (logDenied) {
+          // Non-audit modes: log immediately
           LOG.warn(
               "DENIED {}: package={}, module={}, args={}",
               op,

--- a/agent/README.md
+++ b/agent/README.md
@@ -80,7 +80,58 @@ This separation enables:
 
 - **STRICT** (default): Block denied access, block on errors. Recommended for production.
 - **PERMISSIVE**: Block denied access, allow on errors. Useful for migration.
-- **AUDIT**: Log only, never block. Useful for policy development.
+- **AUDIT**: Log only, never block. Useful for policy development. See [Audit Mode](#audit-mode) below.
+
+## Audit Mode
+
+Audit mode is designed for initial policy authoring and debugging. Instead of blocking operations, it logs all denials and generates suggested policy at JVM shutdown.
+
+### Running in Audit Mode
+
+```bash
+java -javaagent:jguard-agent.jar \
+     -Djguard.mode=audit \
+     -Djguard.allowUnsignedPolicies=true \
+     -jar myapp.jar
+```
+
+### What Happens
+
+1. **During execution**: Operations that would be denied are logged but allowed to proceed
+2. **At shutdown**: The agent prints a summary of all unique denials
+3. **Suggested policy**: Copy-paste-ready `.jguard` syntax is generated
+
+### Example Output
+
+```
+// ============================================================
+// jGuard Audit Mode - Suggested Policy
+// Based on 5 denied operation(s)
+// ============================================================
+
+// Suggested policy for module 'com.google.api.client':
+security module com.google.api.client {
+    entitle com.google.api.client.. to native.load("*");
+    entitle com.google.api.client.. to system.property.read("*");
+    entitle com.google.api.client.. to threads.create;
+}
+
+// Suggested policy for module 'io.netty.common':
+security module io.netty.common {
+    entitle io.netty.common.. to threads.create;
+}
+```
+
+### Workflow
+
+1. Run your application in audit mode
+2. Exercise all code paths (run tests, simulate production load)
+3. Copy the suggested policy output
+4. Paste into your `.jguard` files
+5. Review and refine (remove unnecessary wildcards, tighten paths)
+6. Switch to strict mode for production
+
+This approach discovers all missing entitlements in one run instead of iteratively hitting denials one-by-one.
 
 ## Instrumented Classes (Read Operations)
 

--- a/agent/src/main/java/io/jguard/agent/PolicyEnforcer.java
+++ b/agent/src/main/java/io/jguard/agent/PolicyEnforcer.java
@@ -10,6 +10,7 @@ package io.jguard.agent;
 import io.jguard.bootstrap.AgentConfig;
 import io.jguard.bootstrap.AgentLogger;
 import io.jguard.bootstrap.CallerContext;
+import io.jguard.bootstrap.EnforcementMode;
 import io.jguard.bootstrap.Operation;
 import io.jguard.policy.model.ApplicationPolicy;
 import io.jguard.policy.model.CapabilityArgument;
@@ -20,9 +21,12 @@ import io.jguard.policy.model.SubjectPattern;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -43,6 +47,12 @@ public final class PolicyEnforcer {
   // Cache: "module:package:capability:args" -> allowed
   private final Map<String, Boolean> decisionCache = new ConcurrentHashMap<>();
 
+  // Audit mode denial accumulation: module -> set of (capability, hasArgs)
+  private final Map<String, Set<AuditDenial>> auditDenials = new ConcurrentHashMap<>();
+
+  // Track if shutdown hook has been registered
+  private static volatile boolean shutdownHookRegistered = false;
+
   /**
    * Creates a PolicyEnforcer for a multi-module application policy.
    *
@@ -53,6 +63,7 @@ public final class PolicyEnforcer {
     this.policy = policy;
     this.config = config;
     indexEntitlements();
+    registerAuditShutdownHook();
     LOG.info(
         "PolicyEnforcer initialized for {} module(s): {}",
         policy.modules().size(),
@@ -144,6 +155,8 @@ public final class PolicyEnforcer {
     Optional<ModulePolicy> modulePolicy = getModulePolicy(callerModule, callerPackage);
     if (modulePolicy.isEmpty()) {
       LOG.debug("No policy for module: {}", callerModule);
+      // Record denial for audit mode - use caller module since no policy exists
+      recordAuditDenial(callerModule, op, arg0);
       return deniedNoPolicy(callerPackage, callerModule, formatDetails(op, arg0, arg1));
     }
 
@@ -183,9 +196,12 @@ public final class PolicyEnforcer {
       decisionCache.put(cacheKey, allowed);
     }
 
-    return allowed
-        ? null
-        : denied(callerPackage, op.capabilityName(), formatDetails(op, arg0, arg1));
+    if (!allowed) {
+      // Record denial for audit mode suggested policy output
+      recordAuditDenial(moduleName, op, arg0);
+      return denied(callerPackage, op.capabilityName(), formatDetails(op, arg0, arg1));
+    }
+    return null;
   }
 
   /**
@@ -824,5 +840,184 @@ public final class PolicyEnforcer {
         || moduleName.startsWith("javafx.")
         || moduleName.startsWith("oracle.")
         || moduleName.equals("java.base");
+  }
+
+  // ========== AUDIT MODE DENIAL TRACKING ==========
+
+  /**
+   * Records a denial for audit mode policy suggestion output.
+   *
+   * <p>Only records when in audit mode. Denials are deduplicated and grouped by module for the
+   * suggested policy output at shutdown.
+   *
+   * @param moduleName the module that was denied
+   * @param op the operation that was denied
+   * @param arg0 the primary argument (may be null for SIMPLE operations)
+   */
+  private void recordAuditDenial(String moduleName, Operation op, Object arg0) {
+    if (config.mode() != EnforcementMode.AUDIT) {
+      return;
+    }
+
+    // Determine if this operation type uses arguments
+    boolean hasArgs = operationHasArgs(op);
+
+    AuditDenial denial = new AuditDenial(op.capabilityName(), hasArgs);
+    auditDenials.computeIfAbsent(moduleName, k -> ConcurrentHashMap.newKeySet()).add(denial);
+  }
+
+  /**
+   * Returns true if the operation type uses arguments in policy syntax.
+   *
+   * <p>Operations with arguments need wildcard patterns in the suggested policy.
+   */
+  private static boolean operationHasArgs(Operation op) {
+    return switch (op.category()) {
+      case FILESYSTEM -> true; // fs.read/fs.write take (root, glob)
+      case TARGET_PATTERN -> true; // native.load, env.read, system.property.* take (pattern)
+      case HOST_PORT -> true; // network.outbound takes (host, port)
+      case PORT -> true; // network.listen takes (port)
+      case SIMPLE -> false; // threads.create, crypto.provider, etc. take no args
+    };
+  }
+
+  /**
+   * Registers a shutdown hook to print suggested policy in audit mode.
+   *
+   * <p>Only registers once per JVM to avoid duplicate hooks when PolicyEnforcer is recreated during
+   * hot reload.
+   */
+  private void registerAuditShutdownHook() {
+    if (config.mode() != EnforcementMode.AUDIT) {
+      return;
+    }
+
+    synchronized (PolicyEnforcer.class) {
+      if (shutdownHookRegistered) {
+        return;
+      }
+      shutdownHookRegistered = true;
+
+      Runtime.getRuntime()
+          .addShutdownHook(
+              new Thread(
+                  () -> {
+                    printSuggestedPolicy();
+                  },
+                  "jguard-audit-policy-printer"));
+      LOG.debug("Registered audit mode shutdown hook for suggested policy output");
+    }
+  }
+
+  /**
+   * Prints the suggested policy based on accumulated audit denials.
+   *
+   * <p>Output format is valid .jguard syntax that users can copy into their policy files.
+   */
+  private void printSuggestedPolicy() {
+    if (auditDenials.isEmpty()) {
+      return;
+    }
+
+    StringBuilder sb = new StringBuilder();
+    sb.append("\n");
+    sb.append("// ============================================================\n");
+    sb.append("// jGuard Audit Mode - Suggested Policy\n");
+    sb.append("// Based on ").append(countTotalDenials()).append(" denied operation(s)\n");
+    sb.append("// ============================================================\n");
+    sb.append("\n");
+
+    // Sort modules for consistent output
+    List<String> sortedModules = new ArrayList<>(auditDenials.keySet());
+    sortedModules.sort(Comparator.naturalOrder());
+
+    for (String moduleName : sortedModules) {
+      Set<AuditDenial> denials = auditDenials.get(moduleName);
+      if (denials == null || denials.isEmpty()) {
+        continue;
+      }
+
+      sb.append("// Suggested policy for module '").append(moduleName).append("':\n");
+      sb.append("security module ").append(moduleName).append(" {\n");
+
+      // Sort denials for consistent output
+      List<AuditDenial> sortedDenials = new ArrayList<>(denials);
+      sortedDenials.sort(Comparator.comparing(AuditDenial::capability));
+
+      for (AuditDenial denial : sortedDenials) {
+        sb.append("    entitle ").append(moduleName).append(".. to ").append(denial.capability());
+
+        if (denial.hasArgs()) {
+          sb.append(formatWildcardArgs(denial.capability()));
+        }
+
+        sb.append(";\n");
+      }
+
+      sb.append("}\n\n");
+    }
+
+    // Print to stderr so it's visible even if stdout is captured
+    System.err.print(sb);
+  }
+
+  /**
+   * Formats wildcard arguments for a capability based on its type.
+   *
+   * @param capability the capability name
+   * @return the wildcard argument string (e.g., '("*")' or '("/", "**")')
+   */
+  private static String formatWildcardArgs(String capability) {
+    return switch (capability) {
+      case "fs.read", "fs.write", "fs.hardlink" -> "(\"/\", \"**\")";
+      case "network.outbound" -> "(\"*\", \"1-65535\")";
+      case "network.listen" -> "";
+      case "native.load",
+          "env.read",
+          "system.property.read",
+          "system.property.write",
+          "process.exec" ->
+          "(\"*\")";
+      default -> "(\"*\")";
+    };
+  }
+
+  /** Counts total unique denials across all modules. */
+  private int countTotalDenials() {
+    return auditDenials.values().stream().mapToInt(Set::size).sum();
+  }
+
+  /**
+   * Returns the current audit denials map (for testing).
+   *
+   * @return unmodifiable view of the audit denials
+   */
+  Map<String, Set<AuditDenial>> getAuditDenials() {
+    return Map.copyOf(auditDenials);
+  }
+
+  /**
+   * Record class for tracking unique audit denials.
+   *
+   * <p>Two denials are equal if they have the same capability name. The hasArgs flag is used for
+   * output formatting but doesn't affect equality - we want to deduplicate by capability.
+   */
+  record AuditDenial(String capability, boolean hasArgs) implements Comparable<AuditDenial> {
+    @Override
+    public int compareTo(AuditDenial other) {
+      return this.capability.compareTo(other.capability);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) return true;
+      if (!(obj instanceof AuditDenial other)) return false;
+      return capability.equals(other.capability);
+    }
+
+    @Override
+    public int hashCode() {
+      return capability.hashCode();
+    }
   }
 }

--- a/agent/src/test/java/io/jguard/agent/PolicyEnforcerTest.java
+++ b/agent/src/test/java/io/jguard/agent/PolicyEnforcerTest.java
@@ -1826,4 +1826,150 @@ class PolicyEnforcerTest {
           .hasMessageContaining("runtime.shutdown_hook");
     }
   }
+
+  @Nested
+  @DisplayName("Audit mode denial accumulation")
+  class AuditModeDenialTest {
+
+    private PolicyEnforcer createAuditEnforcer(PolicyDescriptor policy) {
+      AgentConfig config =
+          new AgentConfig.Builder()
+              .policyPath(tempDir.resolve("policy.bin"))
+              .mode(EnforcementMode.AUDIT)
+              .build();
+      return new PolicyEnforcer(policy, config);
+    }
+
+    @Test
+    @DisplayName("records denials in audit mode")
+    void recordsDenialsInAuditMode() {
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of());
+      PolicyEnforcer enforcer = createAuditEnforcer(policy);
+
+      // Trigger denials (in audit mode, these return SecurityException but don't throw)
+      SecurityException denial1 =
+          enforcer.check(caller("com.example.app"), Operation.FS_READ, dataFile, 0);
+      SecurityException denial2 =
+          enforcer.check(caller("com.example.app"), Operation.THREAD_CREATE, "test", 0);
+      SecurityException denial3 =
+          enforcer.check(caller("com.example.app"), Operation.NATIVE_LOAD, "libfoo", 0);
+
+      // All should return denials
+      assert denial1 != null : "Expected fs.read denial";
+      assert denial2 != null : "Expected threads.create denial";
+      assert denial3 != null : "Expected native.load denial";
+
+      // Check that denials were recorded
+      var denials = enforcer.getAuditDenials();
+      assert denials.containsKey("com.example.app") : "Should have denials for module";
+
+      var moduleDenials = denials.get("com.example.app");
+      assert moduleDenials.size() == 3 : "Should have 3 unique denials";
+
+      // Check specific denials
+      assert moduleDenials.stream().anyMatch(d -> d.capability().equals("fs.read"))
+          : "Should have fs.read denial";
+      assert moduleDenials.stream().anyMatch(d -> d.capability().equals("threads.create"))
+          : "Should have threads.create denial";
+      assert moduleDenials.stream().anyMatch(d -> d.capability().equals("native.load"))
+          : "Should have native.load denial";
+    }
+
+    @Test
+    @DisplayName("deduplicates repeated denials for same capability")
+    void deduplicatesRepeatedDenials() {
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of());
+      PolicyEnforcer enforcer = createAuditEnforcer(policy);
+
+      // Trigger the same denial multiple times
+      enforcer.check(caller("com.example.app"), Operation.FS_READ, dataFile, 0);
+      enforcer.check(caller("com.example.app"), Operation.FS_READ, dataSubFile, 0);
+      enforcer.check(caller("com.example.app"), Operation.FS_READ, outsideFile, 0);
+
+      var denials = enforcer.getAuditDenials();
+      var moduleDenials = denials.get("com.example.app");
+
+      // Should only have one fs.read denial despite multiple triggers
+      assert moduleDenials.size() == 1 : "Should deduplicate to 1 denial";
+      assert moduleDenials.stream().anyMatch(d -> d.capability().equals("fs.read"))
+          : "Should have fs.read denial";
+    }
+
+    @Test
+    @DisplayName("does not record denials in strict mode")
+    void doesNotRecordInStrictMode() {
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of());
+      PolicyEnforcer enforcer = createEnforcer(policy); // STRICT mode from helper
+
+      // Trigger a denial (this will throw because we're in strict mode)
+      try {
+        checkFsRead(enforcer, caller("com.example.app"), dataFile);
+        assert false : "Should have thrown";
+      } catch (SecurityException e) {
+        // expected
+      }
+
+      // No denials should be recorded in strict mode
+      var denials = enforcer.getAuditDenials();
+      assert denials.isEmpty() : "Should not record denials in strict mode";
+    }
+
+    @Test
+    @DisplayName("groups denials by module")
+    void groupsDenialsByModule() {
+      // Two modules with no entitlements
+      ModulePolicy module1 = new ModulePolicy("com.example.core", List.of());
+      ModulePolicy module2 = new ModulePolicy("com.example.web", List.of());
+      ApplicationPolicy policy = ApplicationPolicy.create(List.of(module1, module2));
+
+      AgentConfig config =
+          new AgentConfig.Builder()
+              .policyPath(tempDir.resolve("policy.bin"))
+              .mode(EnforcementMode.AUDIT)
+              .build();
+      PolicyEnforcer enforcer = new PolicyEnforcer(policy, config);
+
+      // Trigger denials from different modules
+      enforcer.check(
+          caller("com.example.core.impl", "com.example.core"), Operation.FS_READ, dataFile, 0);
+      enforcer.check(
+          caller("com.example.web.servlet", "com.example.web"), Operation.THREAD_CREATE, "test", 0);
+
+      var denials = enforcer.getAuditDenials();
+
+      // Should have separate entries for each module
+      assert denials.containsKey("com.example.core") : "Should have core module denials";
+      assert denials.containsKey("com.example.web") : "Should have web module denials";
+
+      assert denials.get("com.example.core").stream()
+              .anyMatch(d -> d.capability().equals("fs.read"))
+          : "Core should have fs.read denial";
+      assert denials.get("com.example.web").stream()
+              .anyMatch(d -> d.capability().equals("threads.create"))
+          : "Web should have threads.create denial";
+    }
+
+    @Test
+    @DisplayName("marks operations with args correctly")
+    void marksOperationsWithArgsCorrectly() {
+      PolicyDescriptor policy = PolicyDescriptor.create("com.example.app", List.of());
+      PolicyEnforcer enforcer = createAuditEnforcer(policy);
+
+      // Simple operation (no args)
+      enforcer.check(caller("com.example.app"), Operation.THREAD_CREATE, "test", 0);
+      // Operation with args
+      enforcer.check(caller("com.example.app"), Operation.NATIVE_LOAD, "libfoo", 0);
+
+      var denials = enforcer.getAuditDenials().get("com.example.app");
+
+      // Find the denials
+      var threadsCreateDenial =
+          denials.stream().filter(d -> d.capability().equals("threads.create")).findFirst().get();
+      var nativeLoadDenial =
+          denials.stream().filter(d -> d.capability().equals("native.load")).findFirst().get();
+
+      assert !threadsCreateDenial.hasArgs() : "threads.create should not have args";
+      assert nativeLoadDenial.hasArgs() : "native.load should have args";
+    }
+  }
 }

--- a/gradle-plugin/src/main/java/io/jguard/gradle/policy/JGuardPolicyPlugin.java
+++ b/gradle-plugin/src/main/java/io/jguard/gradle/policy/JGuardPolicyPlugin.java
@@ -19,6 +19,7 @@ import org.gradle.api.plugins.ApplicationPlugin;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.Delete;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
@@ -177,6 +178,18 @@ public class JGuardPolicyPlugin implements Plugin<Project> {
                     File sourceDir = extension.getTestPoliciesSourceDir().get().getAsFile();
                     return sourceDir.exists() && sourceDir.isDirectory();
                   });
+            });
+
+    // Register policy output directories with the clean task
+    // This ensures ./gradlew clean removes stale .bin files
+    project
+        .getTasks()
+        .named(
+            "clean",
+            Delete.class,
+            clean -> {
+              clean.delete(project.getLayout().getBuildDirectory().dir("jguard-policy"));
+              clean.delete(project.getLayout().getBuildDirectory().dir("test-policies"));
             });
 
     // Integrate with jar task if Java plugin is applied


### PR DESCRIPTION
## Description
Audit mode improvements:
- Accumulate all unique denials instead of logging one-by-one
- Print summary at JVM shutdown: "X unique denial(s) across Y module(s)"
- Generate copy-paste-ready .jguard policy syntax at shutdown

Gradle plugin:
- Register build/jguard-policy/ and build/test-policies/ with clean task
- Prevents stale .bin files from causing conflicts

Documentation:
- Add Audit Mode section to agent README with workflow guide
- Update CHANGELOG with new features

These changes dramatically speed up initial policy authoring by discovering all missing entitlements in one run and providing suggested policy output.
